### PR TITLE
Remove extra `:` from symbols that are object keys

### DIFF
--- a/src/ser/serializer.rs
+++ b/src/ser/serializer.rs
@@ -490,7 +490,7 @@ impl<'a> super::SerializeObject for &'a mut Serializer {
     where
         T: serde::Serialize,
     {
-        self.write_symbol(&format!("@{key}"));
+        self.write_symbol(&format!("@{}", key.as_str()));
 
         T::serialize(value, &mut **self)
     }


### PR DESCRIPTION
This fixes a bug where alox-48 inserts a `:` character at the beginning of the names of the fields of objects when serializing. This is not supposed to happen and will lead to errors during deserialization.