### PR TITLE
Implement serialization/deserialization for Ruby bignums

### DIFF
--- a/alox-48/Cargo.toml
+++ b/alox-48/Cargo.toml
@@ -13,6 +13,8 @@ readme = "../README.md"
 [dependencies]
 enum-as-inner = "0.6"
 indexmap = { version = "2.0", features = ["serde", "std"] }
+num-bigint = "0.5"
+num-traits = "0.2"
 thiserror = "1.0"
 paste = "1.0"
 

--- a/alox-48/examples/rmxp_structs.rs
+++ b/alox-48/examples/rmxp_structs.rs
@@ -25,7 +25,7 @@ impl Default for Color {
 #[derive(Debug, Deserialize)]
 #[marshal(from = "alox_48::Value")]
 pub enum ParameterType {
-    Integer(i32),
+    Integer(num_bigint::BigInt),
     String(String),
     Color(Color),
     Tone(Tone),
@@ -63,8 +63,15 @@ impl From<alox_48::Value> for ParameterType {
                     volume: obj.fields[symbol!("volume")]
                         .clone()
                         .into_integer()
-                        .unwrap() as _,
-                    pitch: obj.fields[symbol!("pitch")].clone().into_integer().unwrap() as _,
+                        .unwrap()
+                        .try_into()
+                        .unwrap(),
+                    pitch: obj.fields[symbol!("pitch")]
+                        .clone()
+                        .into_integer()
+                        .unwrap()
+                        .try_into()
+                        .unwrap(),
                 })
             }
             Value::Object(obj) if obj.class == "RPG::MoveRoute" => {
@@ -83,8 +90,12 @@ impl From<alox_48::Value> for ParameterType {
                             let obj = obj.into_object().unwrap();
 
                             rpg::MoveCommand {
-                                code: obj.fields[symbol!("code")].clone().into_integer().unwrap()
-                                    as _,
+                                code: obj.fields[symbol!("code")]
+                                    .clone()
+                                    .into_integer()
+                                    .unwrap()
+                                    .try_into()
+                                    .unwrap(),
                                 parameters: obj.fields[symbol!("parameters")]
                                     .clone()
                                     .into_array()
@@ -98,7 +109,12 @@ impl From<alox_48::Value> for ParameterType {
             }
             Value::Object(obj) if obj.class == "RPG::MoveCommand" => {
                 Self::MoveCommand(rpg::MoveCommand {
-                    code: obj.fields[symbol!("code")].clone().into_integer().unwrap() as _,
+                    code: obj.fields[symbol!("code")]
+                        .clone()
+                        .into_integer()
+                        .unwrap()
+                        .try_into()
+                        .unwrap(),
                     parameters: obj.fields[symbol!("parameters")]
                         .clone()
                         .into_array()

--- a/alox-48/examples/rmxp_structs.rs
+++ b/alox-48/examples/rmxp_structs.rs
@@ -1,6 +1,7 @@
 #![allow(dead_code, missing_docs)]
 
-use alox_48::Deserialize;
+use alox_48::{Bignum, Deserialize, Fixnum};
+use num_traits::ToPrimitive;
 
 #[derive(Debug, Deserialize)]
 pub struct Color {
@@ -25,7 +26,8 @@ impl Default for Color {
 #[derive(Debug, Deserialize)]
 #[marshal(from = "alox_48::Value")]
 pub enum ParameterType {
-    Integer(num_bigint::BigInt),
+    Fixnum(Fixnum),
+    Bignum(Bignum),
     String(String),
     Color(Color),
     Tone(Tone),
@@ -50,7 +52,8 @@ impl From<alox_48::Value> for ParameterType {
         println!("{value:#?}");
 
         match value {
-            Value::Integer(i) => Self::Integer(i as _),
+            Value::Fixnum(i) => Self::Fixnum(i),
+            Value::Bignum(i) => Self::Bignum(i),
             Value::String(str) => Self::String(str.to_string_lossy().into_owned()),
             Value::Object(obj) if obj.class == "RPG::AudioFile" => {
                 Self::AudioFile(rpg::AudioFile {
@@ -62,15 +65,15 @@ impl From<alox_48::Value> for ParameterType {
                         .into_owned(),
                     volume: obj.fields[symbol!("volume")]
                         .clone()
-                        .into_integer()
+                        .into_fixnum()
                         .unwrap()
-                        .try_into()
+                        .to_u8()
                         .unwrap(),
                     pitch: obj.fields[symbol!("pitch")]
                         .clone()
-                        .into_integer()
+                        .into_fixnum()
                         .unwrap()
-                        .try_into()
+                        .to_u8()
                         .unwrap(),
                 })
             }
@@ -92,10 +95,9 @@ impl From<alox_48::Value> for ParameterType {
                             rpg::MoveCommand {
                                 code: obj.fields[symbol!("code")]
                                     .clone()
-                                    .into_integer()
+                                    .into_fixnum()
                                     .unwrap()
-                                    .try_into()
-                                    .unwrap(),
+                                    .into(),
                                 parameters: obj.fields[symbol!("parameters")]
                                     .clone()
                                     .into_array()
@@ -111,10 +113,9 @@ impl From<alox_48::Value> for ParameterType {
                 Self::MoveCommand(rpg::MoveCommand {
                     code: obj.fields[symbol!("code")]
                         .clone()
-                        .into_integer()
+                        .into_fixnum()
                         .unwrap()
-                        .try_into()
-                        .unwrap(),
+                        .into(),
                     parameters: obj.fields[symbol!("parameters")]
                         .clone()
                         .into_array()

--- a/alox-48/examples/rmxp_structs.rs
+++ b/alox-48/examples/rmxp_structs.rs
@@ -1,7 +1,6 @@
 #![allow(dead_code, missing_docs)]
 
-use alox_48::{Bignum, Deserialize, Fixnum};
-use num_traits::ToPrimitive;
+use alox_48::{Bignum, Deserialize, Fixnum, ToPrimitive};
 
 #[derive(Debug, Deserialize)]
 pub struct Color {

--- a/alox-48/src/de/deserializer.rs
+++ b/alox-48/src/de/deserializer.rs
@@ -99,12 +99,16 @@ impl<'de> Cursor<'de> {
     }
 
     fn next_bytes_dyn(&mut self, length: usize) -> Result<&'de [u8]> {
-        if length > self.input.len() {
+        let new_position = self
+            .position
+            .checked_add(length)
+            .ok_or(Error { kind: Kind::Eof })?;
+        if new_position > self.input.len() {
             return Err(Error { kind: Kind::Eof });
         }
 
-        let ret = &self.input[self.position..self.position + length];
-        self.position += length;
+        let ret = &self.input[self.position..new_position];
+        self.position = new_position;
         Ok(ret)
     }
 }

--- a/alox-48/src/de/deserializer.rs
+++ b/alox-48/src/de/deserializer.rs
@@ -10,7 +10,7 @@
 #![allow(clippy::cast_lossless)]
 
 use super::{ignored::Ignored, DeserializeSeed, Error, Kind, Result};
-use crate::{tag::Tag, Deserialize, Sym, Visitor};
+use crate::{tag::Tag, BignumRef, Deserialize, Fixnum, Sym, Visitor};
 
 /// The alox-48 deserializer.
 #[derive(Debug, Clone)]
@@ -312,17 +312,26 @@ impl<'de> super::DeserializerTrait<'de> for &mut Deserializer<'de> {
             Tag::Nil => visitor.visit_nil(),
             Tag::True => visitor.visit_bool(true),
             Tag::False => visitor.visit_bool(false),
-            Tag::Fixnum => visitor.visit_bignum(self.read_packed_int()?.into()),
+            Tag::Fixnum => visitor.visit_fixnum({
+                let int = self.read_packed_int()?;
+                num_traits::FromPrimitive::from_i32(int).ok_or_else(|| Error {
+                    kind: Kind::ParseFixnumOverflow(
+                        num_traits::FromPrimitive::from_i32(int).unwrap(),
+                    ),
+                })?
+            }),
             Tag::Float => visitor.visit_f64(self.read_float()?),
             Tag::Bignum => {
-                let sign = if self.cursor.next_byte()? == b'-' {
-                    num_bigint::Sign::Minus
-                } else {
-                    num_bigint::Sign::Plus
-                };
+                let is_negative = self.cursor.next_byte()? == b'-';
                 let len = 2 * self.read_usize()?;
-                let bytes = self.cursor.next_bytes_dyn(len)?;
-                visitor.visit_bignum(num_bigint::BigInt::from_bytes_le(sign, bytes))
+                let le_bytes = self.cursor.next_bytes_dyn(len)?;
+                visitor.visit_bignum(BignumRef::from_le_bytes(is_negative, le_bytes).ok_or_else(
+                    || Error {
+                        kind: Kind::ParseBignumUnderflow(
+                            Fixnum::from_le_bytes(is_negative, le_bytes).unwrap(),
+                        ),
+                    },
+                )?)
             }
             Tag::String => {
                 let data = self.read_bytes_len()?;

--- a/alox-48/src/de/deserializer.rs
+++ b/alox-48/src/de/deserializer.rs
@@ -312,8 +312,18 @@ impl<'de> super::DeserializerTrait<'de> for &mut Deserializer<'de> {
             Tag::Nil => visitor.visit_nil(),
             Tag::True => visitor.visit_bool(true),
             Tag::False => visitor.visit_bool(false),
-            Tag::Integer => visitor.visit_i32(self.read_packed_int()?),
+            Tag::Fixnum => visitor.visit_bignum(self.read_packed_int()?.into()),
             Tag::Float => visitor.visit_f64(self.read_float()?),
+            Tag::Bignum => {
+                let sign = if self.cursor.next_byte()? == b'-' {
+                    num_bigint::Sign::Minus
+                } else {
+                    num_bigint::Sign::Plus
+                };
+                let len = 2 * self.read_usize()?;
+                let bytes = self.cursor.next_bytes_dyn(len)?;
+                visitor.visit_bignum(num_bigint::BigInt::from_bytes_le(sign, bytes))
+            }
             Tag::String => {
                 let data = self.read_bytes_len()?;
                 visitor.visit_string(data)

--- a/alox-48/src/de/deserializer.rs
+++ b/alox-48/src/de/deserializer.rs
@@ -313,7 +313,10 @@ impl<'de> super::DeserializerTrait<'de> for &mut Deserializer<'de> {
             Tag::Float => visitor.visit_f64(self.read_float()?),
             Tag::Bignum => {
                 let is_negative = self.cursor.next_byte()? == b'-';
-                let len = 2 * self.read_usize()?;
+                let len = self
+                    .read_usize()?
+                    .checked_mul(2)
+                    .ok_or(Error { kind: Kind::Eof })?;
                 let le_bytes = self.cursor.next_bytes_dyn(len)?;
                 if let Some(bignum) = BignumRef::from_le_bytes(is_negative, le_bytes) {
                     visitor.visit_bignum(bignum)

--- a/alox-48/src/de/deserializer.rs
+++ b/alox-48/src/de/deserializer.rs
@@ -10,7 +10,7 @@
 #![allow(clippy::cast_lossless)]
 
 use super::{ignored::Ignored, DeserializeSeed, Error, Kind, Result};
-use crate::{tag::Tag, BignumRef, Deserialize, Fixnum, Sym, Visitor};
+use crate::{tag::Tag, BignumRef, Deserialize, Fixnum, FromPrimitive, Sym, Visitor};
 
 /// The alox-48 deserializer.
 #[derive(Debug, Clone)]
@@ -188,7 +188,7 @@ impl<'de> Deserializer<'de> {
                     x |= n;
                 }
 
-                num_traits::FromPrimitive::from_i32(x).unwrap()
+                FromPrimitive::from_i32(x).unwrap()
             }
             -4..=-1 => {
                 let mut x = -1;
@@ -201,7 +201,7 @@ impl<'de> Deserializer<'de> {
                     x = (x & a) | b;
                 }
 
-                num_traits::FromPrimitive::from_i32(x).unwrap()
+                FromPrimitive::from_i32(x).unwrap()
             }
         })
     }

--- a/alox-48/src/de/deserializer.rs
+++ b/alox-48/src/de/deserializer.rs
@@ -164,7 +164,7 @@ impl<'de> Deserializer<'de> {
         self.cursor.input
     }
 
-    fn read_packed_int(&mut self) -> Result<i32> {
+    fn read_fixnum(&mut self) -> Result<Fixnum> {
         // The bounds of a Ruby Marshal packed integer are [-(2**30), 2**30 - 1], anything beyond that
         // gets serialized as a bignum.
         //
@@ -172,9 +172,9 @@ impl<'de> Deserializer<'de> {
         let c = self.cursor.next_byte()? as i8;
 
         Ok(match c {
-            0 => 0,
-            5..=127 => (c - 5) as _,
-            -128..=-5 => (c + 5) as _,
+            0 => 0i16.into(),
+            5..=127 => (c - 5).into(),
+            -128..=-5 => (c + 5).into(),
             1..=4 => {
                 let mut x = 0;
 
@@ -184,7 +184,7 @@ impl<'de> Deserializer<'de> {
                     x |= n;
                 }
 
-                x
+                num_traits::FromPrimitive::from_i32(x).unwrap()
             }
             -4..=-1 => {
                 let mut x = -1;
@@ -197,9 +197,13 @@ impl<'de> Deserializer<'de> {
                     x = (x & a) | b;
                 }
 
-                x
+                num_traits::FromPrimitive::from_i32(x).unwrap()
             }
         })
+    }
+
+    fn read_usize(&mut self) -> Result<usize> {
+        num_traits::ToPrimitive::to_usize(&self.read_fixnum()?).ok_or(Error { kind: Kind::Eof })
     }
 
     #[allow(clippy::panic_in_result_fn)]
@@ -246,7 +250,7 @@ impl<'de> Deserializer<'de> {
     }
 
     fn read_symlink(&mut self) -> Result<&'de Sym> {
-        let index = self.read_packed_int()? as usize;
+        let index = self.read_usize()?;
 
         self.sym_table.get(index).copied().ok_or(Error {
             kind: Kind::UnresolvedSymlink(index),
@@ -272,13 +276,6 @@ impl<'de> Deserializer<'de> {
             return;
         }
         self.objtable.push(self.cursor.position);
-    }
-
-    fn read_usize(&mut self) -> Result<usize> {
-        let raw_length = self.read_packed_int()?;
-        usize::try_from(raw_length).map_err(|_| Error {
-            kind: Kind::UnexpectedNegativeLength(raw_length),
-        })
     }
 
     fn read_bytes_len(&mut self) -> Result<&'de [u8]> {
@@ -312,14 +309,7 @@ impl<'de> super::DeserializerTrait<'de> for &mut Deserializer<'de> {
             Tag::Nil => visitor.visit_nil(),
             Tag::True => visitor.visit_bool(true),
             Tag::False => visitor.visit_bool(false),
-            Tag::Fixnum => visitor.visit_fixnum({
-                let int = self.read_packed_int()?;
-                num_traits::FromPrimitive::from_i32(int).ok_or_else(|| Error {
-                    kind: Kind::ParseFixnumOverflow(
-                        num_traits::FromPrimitive::from_i32(int).unwrap(),
-                    ),
-                })?
-            }),
+            Tag::Fixnum => visitor.visit_fixnum(self.read_fixnum()?),
             Tag::Float => visitor.visit_f64(self.read_float()?),
             Tag::Bignum => {
                 let is_negative = self.cursor.next_byte()? == b'-';
@@ -458,7 +448,7 @@ impl<'de> super::DeserializerTrait<'de> for &mut Deserializer<'de> {
             }
             // FIXME: this ignores default hash values. we should fix this?
             Tag::HashDefault => {
-                let len = self.read_packed_int()? as _;
+                let len = self.read_usize()?;
                 let mut index = 0;
 
                 let result = visitor.visit_hash(HashAccess {
@@ -518,7 +508,7 @@ impl<'de> super::DeserializerTrait<'de> for &mut Deserializer<'de> {
             Tag::Struct => {
                 let name = self.read_symbol_either()?;
 
-                let len = self.read_packed_int()? as _;
+                let len = self.read_usize()?;
                 let mut index = 0;
 
                 let result = visitor.visit_struct(

--- a/alox-48/src/de/deserializer.rs
+++ b/alox-48/src/de/deserializer.rs
@@ -325,13 +325,11 @@ impl<'de> super::DeserializerTrait<'de> for &mut Deserializer<'de> {
                 let is_negative = self.cursor.next_byte()? == b'-';
                 let len = 2 * self.read_usize()?;
                 let le_bytes = self.cursor.next_bytes_dyn(len)?;
-                visitor.visit_bignum(BignumRef::from_le_bytes(is_negative, le_bytes).ok_or_else(
-                    || Error {
-                        kind: Kind::ParseBignumUnderflow(
-                            Fixnum::from_le_bytes(is_negative, le_bytes).unwrap(),
-                        ),
-                    },
-                )?)
+                if let Some(bignum) = BignumRef::from_le_bytes(is_negative, le_bytes) {
+                    visitor.visit_bignum(bignum)
+                } else {
+                    visitor.visit_fixnum(Fixnum::from_le_bytes(is_negative, le_bytes).unwrap())
+                }
             }
             Tag::String => {
                 let data = self.read_bytes_len()?;

--- a/alox-48/src/de/error.rs
+++ b/alox-48/src/de/error.rs
@@ -46,9 +46,6 @@ pub enum Kind {
     /// A fixnum could not be read because it was outside of the interval $[-2^30, 2^30)$.
     #[error("Failed to parse {0} as a fixnum")]
     ParseFixnumOverflow(Bignum),
-    /// A bignum could not be read because it was inside of the interval $[-2^30, 2^30)$.
-    #[error("Failed to parse {0} as a bignum")]
-    ParseBignumUnderflow(Fixnum),
     /// A float could not be converted to an integer because it was infinite or NaN.
     #[error("Tried to interpret a nonfinite float as an int")]
     InvalidFloatToIntConversion,

--- a/alox-48/src/de/error.rs
+++ b/alox-48/src/de/error.rs
@@ -43,6 +43,13 @@ pub enum Kind {
     /// A float's mantissa was too long.
     #[error("Float mantissa too long")]
     ParseFloatMantissaTooLong,
+    /// A float could not be converted to an integer because it was infinite or NaN.
+    #[error("Tried to interpret a nonfinite float as an int")]
+    InvalidFloatToIntConversion,
+    /// An integer could not be read because it does not fit in the range of the requested integer
+    /// or floating point data type
+    #[error("Numeric value is too large")]
+    NumericOverflow,
     /// A symbol was expected (usually for a class name) and something else was found.
     #[error("Expected a symbol got {0:?}")]
     ExpectedSymbol(Tag),
@@ -76,7 +83,7 @@ fn unknown_tag_to_char(tag: u8) -> char {
 pub enum Unexpected<'a> {
     Nil,
     Bool(bool),
-    Integer(i32),
+    Integer(&'a num_bigint::BigInt),
     Float(f64),
     Hash,
     Array,

--- a/alox-48/src/de/error.rs
+++ b/alox-48/src/de/error.rs
@@ -7,7 +7,7 @@
 
 use std::str::Utf8Error;
 
-use crate::{tag::Tag, Bignum, BignumRef, Fixnum, Sym, Visitor};
+use crate::{tag::Tag, BignumRef, Fixnum, Sym, Visitor};
 
 /// Type alias around a result.
 pub type Result<T> = std::result::Result<T, Error>;
@@ -24,9 +24,6 @@ pub struct Error {
 /// Error type for this crate.
 #[derive(Debug, thiserror::Error)]
 pub enum Kind {
-    /// A length was negative when it should not have been.
-    #[error("Unexpected negative length {0}")]
-    UnexpectedNegativeLength(i32),
     /// Unrecognized tag was encountered.
     #[error("Wrong tag 0x{0:X} ({})", unknown_tag_to_char(*_0))]
     WrongTag(u8),
@@ -43,9 +40,6 @@ pub enum Kind {
     /// A float's mantissa was too long.
     #[error("Float mantissa too long")]
     ParseFloatMantissaTooLong,
-    /// A fixnum could not be read because it was outside of the interval [-2<sup>30</sup>, 2<sup>30</sup>).
-    #[error("Failed to parse {0} as a fixnum")]
-    ParseFixnumOverflow(Bignum),
     /// A float could not be converted to an integer because it was infinite or NaN.
     #[error("Tried to interpret a nonfinite float as an int")]
     InvalidFloatToIntConversion,

--- a/alox-48/src/de/error.rs
+++ b/alox-48/src/de/error.rs
@@ -43,7 +43,7 @@ pub enum Kind {
     /// A float's mantissa was too long.
     #[error("Float mantissa too long")]
     ParseFloatMantissaTooLong,
-    /// A fixnum could not be read because it was outside of the interval $[-2^30, 2^30)$.
+    /// A fixnum could not be read because it was outside of the interval [-2<sup>30</sup>, 2<sup>30</sup>).
     #[error("Failed to parse {0} as a fixnum")]
     ParseFixnumOverflow(Bignum),
     /// A float could not be converted to an integer because it was infinite or NaN.

--- a/alox-48/src/de/error.rs
+++ b/alox-48/src/de/error.rs
@@ -40,13 +40,6 @@ pub enum Kind {
     /// A float's mantissa was too long.
     #[error("Float mantissa too long")]
     ParseFloatMantissaTooLong,
-    /// A float could not be converted to an integer because it was infinite or NaN.
-    #[error("Tried to interpret a nonfinite float as an int")]
-    InvalidFloatToIntConversion,
-    /// An integer could not be read because it does not fit in the range of the requested integer
-    /// or floating point data type
-    #[error("Numeric value is too large")]
-    NumericOverflow,
     /// A symbol was expected (usually for a class name) and something else was found.
     #[error("Expected a symbol got {0:?}")]
     ExpectedSymbol(Tag),

--- a/alox-48/src/de/error.rs
+++ b/alox-48/src/de/error.rs
@@ -7,7 +7,7 @@
 
 use std::str::Utf8Error;
 
-use crate::{tag::Tag, Sym, Visitor};
+use crate::{tag::Tag, Bignum, BignumRef, Fixnum, Sym, Visitor};
 
 /// Type alias around a result.
 pub type Result<T> = std::result::Result<T, Error>;
@@ -43,6 +43,12 @@ pub enum Kind {
     /// A float's mantissa was too long.
     #[error("Float mantissa too long")]
     ParseFloatMantissaTooLong,
+    /// A fixnum could not be read because it was outside of the interval $[-2^30, 2^30)$.
+    #[error("Failed to parse {0} as a fixnum")]
+    ParseFixnumOverflow(Bignum),
+    /// A bignum could not be read because it was inside of the interval $[-2^30, 2^30)$.
+    #[error("Failed to parse {0} as a bignum")]
+    ParseBignumUnderflow(Fixnum),
     /// A float could not be converted to an integer because it was infinite or NaN.
     #[error("Tried to interpret a nonfinite float as an int")]
     InvalidFloatToIntConversion,
@@ -83,7 +89,8 @@ fn unknown_tag_to_char(tag: u8) -> char {
 pub enum Unexpected<'a> {
     Nil,
     Bool(bool),
-    Integer(&'a num_bigint::BigInt),
+    Fixnum(Fixnum),
+    Bignum(BignumRef<'a>),
     Float(f64),
     Hash,
     Array,
@@ -132,7 +139,8 @@ impl std::fmt::Display for Unexpected<'_> {
         match self {
             Unexpected::Nil => f.write_str("nil"),
             Unexpected::Bool(v) => write!(f, "bool `{v}`"),
-            Unexpected::Integer(v) => write!(f, "integer `{v}`"),
+            Unexpected::Fixnum(v) => write!(f, "fixnum `{v}`"),
+            Unexpected::Bignum(v) => write!(f, "bignum `{v}`"),
             Unexpected::Float(v) => write!(f, "float `{v}`"),
             Unexpected::Hash => write!(f, "hash"),
             Unexpected::Array => write!(f, "array"),

--- a/alox-48/src/de/ignored.rs
+++ b/alox-48/src/de/ignored.rs
@@ -25,7 +25,7 @@ impl<'de> Visitor<'de> for IgnoredVisitor {
     fn visit_bool(self, _v: bool) -> Result<Self::Value> {
         Ok(Ignored)
     }
-    fn visit_i32(self, _v: i32) -> Result<Self::Value> {
+    fn visit_bignum(self, _v: num_bigint::BigInt) -> Result<Self::Value> {
         Ok(Ignored)
     }
     fn visit_f64(self, _v: f64) -> Result<Self::Value> {

--- a/alox-48/src/de/ignored.rs
+++ b/alox-48/src/de/ignored.rs
@@ -4,7 +4,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 use super::{traits::InstanceAccess, Deserialize, Result, Visitor};
-use crate::{DeserializerTrait, IvarAccess, Sym};
+use crate::{BignumRef, DeserializerTrait, Fixnum, IvarAccess, Sym};
 
 /// A type that implements deserialize which ignores all values.
 #[derive(Clone, Copy, Debug, Default)]
@@ -25,7 +25,10 @@ impl<'de> Visitor<'de> for IgnoredVisitor {
     fn visit_bool(self, _v: bool) -> Result<Self::Value> {
         Ok(Ignored)
     }
-    fn visit_bignum(self, _v: num_bigint::BigInt) -> Result<Self::Value> {
+    fn visit_fixnum(self, _v: Fixnum) -> Result<Self::Value> {
+        Ok(Ignored)
+    }
+    fn visit_bignum(self, _v: BignumRef<'de>) -> Result<Self::Value> {
         Ok(Ignored)
     }
     fn visit_f64(self, _v: f64) -> Result<Self::Value> {

--- a/alox-48/src/de/impls.rs
+++ b/alox-48/src/de/impls.rs
@@ -18,7 +18,7 @@ use std::{
 
 use super::{
     traits::VisitorOption, ArrayAccess, Deserialize, DeserializeSeed, DeserializerTrait, Error,
-    HashAccess, Result, Unexpected, Visitor,
+    HashAccess, Kind, Result, Unexpected, Visitor,
 };
 use crate::Sym;
 
@@ -39,18 +39,21 @@ where
 struct IntVisitor;
 
 impl Visitor<'_> for IntVisitor {
-    type Value = i32;
+    type Value = num_bigint::BigInt;
 
     fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         formatter.write_str("an integer")
     }
 
-    fn visit_i32(self, v: i32) -> Result<Self::Value> {
+    fn visit_bignum(self, v: num_bigint::BigInt) -> Result<Self::Value> {
         Ok(v)
     }
 
     fn visit_f64(self, v: f64) -> Result<Self::Value> {
-        Ok(v as i32)
+        use num_traits::FromPrimitive;
+        num_bigint::BigInt::from_f64(v).ok_or(Error {
+            kind: Kind::InvalidFloatToIntConversion,
+        })
     }
 }
 
@@ -62,7 +65,7 @@ macro_rules! primitive_int_impl {
                 D: DeserializerTrait<'de>,
             {
                 let i = deserializer.deserialize(IntVisitor)?;
-                Ok(i as _)
+                i.try_into().map_err(|_| Error { kind: Kind::NumericOverflow })
             }
         })*
     };
@@ -71,24 +74,44 @@ macro_rules! primitive_int_impl {
 struct NonZeroIntVisitor;
 
 impl Visitor<'_> for NonZeroIntVisitor {
-    type Value = std::num::NonZeroI32;
+    type Value = num_bigint::BigInt;
 
     fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         formatter.write_str("a non-zero integer")
     }
 
-    fn visit_i32(self, v: i32) -> Result<Self::Value> {
-        std::num::NonZeroI32::new(v)
-            .ok_or_else(|| Error::invalid_value(Unexpected::Integer(v), &self))
+    fn visit_bignum(self, v: num_bigint::BigInt) -> Result<Self::Value> {
+        if v == num_bigint::BigInt::ZERO {
+            Err(Error::invalid_value(Unexpected::Integer(&v), &self))
+        } else {
+            Ok(v)
+        }
     }
 
     fn visit_f64(self, v: f64) -> Result<Self::Value> {
-        std::num::NonZeroI32::new(v as i32)
-            .ok_or_else(|| Error::invalid_value(Unexpected::Integer(v as i32), &self))
+        use num_traits::FromPrimitive;
+        self.visit_bignum(num_bigint::BigInt::from_f64(v).ok_or(Error {
+            kind: Kind::InvalidFloatToIntConversion,
+        })?)
     }
 }
 
-primitive_int_impl!(u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize);
+primitive_int_impl!(
+    u8,
+    u16,
+    u32,
+    u64,
+    u128,
+    usize,
+    num_bigint::BigUint,
+    i8,
+    i16,
+    i32,
+    i64,
+    i128,
+    isize,
+    num_bigint::BigInt
+);
 
 macro_rules! nonzero_int_impl {
     ($($primitive:ty),*) => {
@@ -97,10 +120,10 @@ macro_rules! nonzero_int_impl {
             where
                 D: DeserializerTrait<'de>,
             {
-                let i = deserializer.deserialize(NonZeroIntVisitor)?.get();
-                // we've already asserted that it's non-zero simply by the fact that NonZeroIntVisitor returns a NonZeroI32.
+                let i = deserializer.deserialize(NonZeroIntVisitor)?;
+                // we've already asserted that it's non-zero simply by the fact that NonZeroIntVisitor returns a nonzero integer.
                 // so this new_unchecked is safe
-                Ok(unsafe { <$primitive>::new_unchecked(i as _) })
+                Ok(unsafe { <$primitive>::new_unchecked(i.try_into().map_err(|_| Error { kind: Kind::NumericOverflow })?) })
             }
         })*
     };
@@ -176,8 +199,11 @@ impl Visitor<'_> for FloatVisitor {
         formatter.write_str("a float")
     }
 
-    fn visit_i32(self, v: i32) -> Result<Self::Value> {
-        Ok(f64::from(v))
+    fn visit_bignum(self, v: num_bigint::BigInt) -> Result<Self::Value> {
+        use num_traits::ToPrimitive;
+        v.to_f64().ok_or(Error {
+            kind: Kind::NumericOverflow,
+        })
     }
 
     fn visit_f64(self, v: f64) -> Result<Self::Value> {

--- a/alox-48/src/de/impls.rs
+++ b/alox-48/src/de/impls.rs
@@ -20,7 +20,7 @@ use super::{
     traits::VisitorOption, ArrayAccess, Deserialize, DeserializeSeed, DeserializerTrait, Error,
     HashAccess, Result, Unexpected, Visitor,
 };
-use crate::{Bignum, BignumRef, Fixnum, Sym};
+use crate::{Bignum, BignumRef, Fixnum, FromPrimitive, Sym, ToPrimitive};
 
 impl<'de, T> DeserializeSeed<'de> for PhantomData<T>
 where
@@ -69,13 +69,12 @@ where
     }
 
     fn visit_f64(self, v: f64) -> Result<Self::Value> {
-        if let Some(fixnum) = num_traits::FromPrimitive::from_f64(v) {
+        if let Some(fixnum) = FromPrimitive::from_f64(v) {
             self.visit_fixnum(fixnum)
         } else {
-            Ok(IntVisitorValue::Bignum(
-                num_traits::FromPrimitive::from_f64(v)
-                    .ok_or(Error::invalid_value(Unexpected::Float(v), &self))?,
-            ))
+            Ok(IntVisitorValue::Bignum(FromPrimitive::from_f64(v).ok_or(
+                Error::invalid_value(Unexpected::Float(v), &self),
+            )?))
         }
     }
 }
@@ -89,9 +88,9 @@ macro_rules! primitive_int_impl {
             {
                 let visitor = IntVisitor::<'de, $primitive>(PhantomData);
                 match deserializer.deserialize(visitor)? {
-                    IntVisitorValue::Fixnum(v) => num_traits::ToPrimitive::$to_primitive(&v).ok_or(Error::invalid_value(Unexpected::Fixnum(v), &visitor)),
-                    IntVisitorValue::Bignum(v) => num_traits::ToPrimitive::$to_primitive(&v).ok_or(Error::invalid_value(Unexpected::Bignum(v.as_ref()), &visitor)),
-                    IntVisitorValue::BignumRef(v) => num_traits::ToPrimitive::$to_primitive(&v).ok_or(Error::invalid_value(Unexpected::Bignum(v), &visitor)),
+                    IntVisitorValue::Fixnum(v) => v.$to_primitive().ok_or(Error::invalid_value(Unexpected::Fixnum(v), &visitor)),
+                    IntVisitorValue::Bignum(v) => v.$to_primitive().ok_or(Error::invalid_value(Unexpected::Bignum(v.as_ref()), &visitor)),
+                    IntVisitorValue::BignumRef(v) => v.$to_primitive().ok_or(Error::invalid_value(Unexpected::Bignum(v), &visitor)),
                 }
             }
         })*
@@ -129,13 +128,12 @@ where
     }
 
     fn visit_f64(self, v: f64) -> Result<Self::Value> {
-        if let Some(fixnum) = num_traits::FromPrimitive::from_f64(v) {
+        if let Some(fixnum) = FromPrimitive::from_f64(v) {
             self.visit_fixnum(fixnum)
         } else {
-            Ok(IntVisitorValue::Bignum(
-                num_traits::FromPrimitive::from_f64(v)
-                    .ok_or(Error::invalid_value(Unexpected::Float(v), &self))?,
-            ))
+            Ok(IntVisitorValue::Bignum(FromPrimitive::from_f64(v).ok_or(
+                Error::invalid_value(Unexpected::Float(v), &self),
+            )?))
         }
     }
 }
@@ -164,9 +162,9 @@ macro_rules! nonzero_int_impl {
             {
                 let visitor = NonZeroIntVisitor::<'de, $primitive>(PhantomData);
                 let i = match deserializer.deserialize(visitor)? {
-                    IntVisitorValue::Fixnum(v) => num_traits::ToPrimitive::$to_primitive(&v).ok_or(Error::invalid_value(Unexpected::Fixnum(v), &visitor)),
-                    IntVisitorValue::Bignum(v) => num_traits::ToPrimitive::$to_primitive(&v).ok_or(Error::invalid_value(Unexpected::Bignum(v.as_ref()), &visitor)),
-                    IntVisitorValue::BignumRef(v) => num_traits::ToPrimitive::$to_primitive(&v).ok_or(Error::invalid_value(Unexpected::Bignum(v), &visitor)),
+                    IntVisitorValue::Fixnum(v) => v.$to_primitive().ok_or(Error::invalid_value(Unexpected::Fixnum(v), &visitor)),
+                    IntVisitorValue::Bignum(v) => v.$to_primitive().ok_or(Error::invalid_value(Unexpected::Bignum(v.as_ref()), &visitor)),
+                    IntVisitorValue::BignumRef(v) => v.$to_primitive().ok_or(Error::invalid_value(Unexpected::Bignum(v), &visitor)),
                 }?;
                 // we've already asserted that it's non-zero simply by the fact that NonZeroIntVisitor returns a nonzero integer.
                 // so this new_unchecked is safe

--- a/alox-48/src/de/impls.rs
+++ b/alox-48/src/de/impls.rs
@@ -20,7 +20,7 @@ use super::{
     traits::VisitorOption, ArrayAccess, Deserialize, DeserializeSeed, DeserializerTrait, Error,
     HashAccess, Result, Unexpected, Visitor,
 };
-use crate::{Bignum, BignumRef, Fixnum, FromPrimitive, Sym, ToPrimitive};
+use crate::{BignumRef, Fixnum, NumCast, Sym};
 
 impl<'de, T> DeserializeSeed<'de> for PhantomData<T>
 where
@@ -36,20 +36,13 @@ where
     }
 }
 
-#[derive(Clone, Copy)]
 struct IntVisitor<'de, T>(PhantomData<&'de T>);
-
-enum IntVisitorValue<'de> {
-    Fixnum(Fixnum),
-    Bignum(Bignum),
-    BignumRef(BignumRef<'de>),
-}
 
 impl<'de, T> Visitor<'de> for IntVisitor<'de, T>
 where
-    T: std::fmt::Display + num_traits::Bounded,
+    T: std::fmt::Display + num_traits::Bounded + NumCast,
 {
-    type Value = IntVisitorValue<'de>;
+    type Value = T;
 
     fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let min = T::min_value();
@@ -61,50 +54,53 @@ where
     }
 
     fn visit_fixnum(self, v: Fixnum) -> Result<Self::Value> {
-        Ok(IntVisitorValue::Fixnum(v))
+        T::from(v).ok_or(Error::invalid_value(Unexpected::Fixnum(v), &self))
     }
 
     fn visit_bignum(self, v: BignumRef<'de>) -> Result<Self::Value> {
-        Ok(IntVisitorValue::BignumRef(v))
+        T::from(v).ok_or(Error::invalid_value(Unexpected::Bignum(v), &self))
     }
 
     fn visit_f64(self, v: f64) -> Result<Self::Value> {
-        if let Some(fixnum) = FromPrimitive::from_f64(v) {
-            self.visit_fixnum(fixnum)
-        } else {
-            Ok(IntVisitorValue::Bignum(FromPrimitive::from_f64(v).ok_or(
-                Error::invalid_value(Unexpected::Float(v), &self),
-            )?))
-        }
+        T::from(v).ok_or(Error::invalid_value(Unexpected::Float(v), &self))
     }
 }
 
 macro_rules! primitive_int_impl {
-    ($($primitive:ty => $to_primitive:ident),* $(,)?) => {
+    ($($primitive:ty),* $(,)?) => {
         $(impl<'de> Deserialize<'de> for $primitive {
             fn deserialize<D>(deserializer: D) -> Result<Self>
             where
                 D: DeserializerTrait<'de>,
             {
-                let visitor = IntVisitor::<'de, $primitive>(PhantomData);
-                match deserializer.deserialize(visitor)? {
-                    IntVisitorValue::Fixnum(v) => v.$to_primitive().ok_or(Error::invalid_value(Unexpected::Fixnum(v), &visitor)),
-                    IntVisitorValue::Bignum(v) => v.$to_primitive().ok_or(Error::invalid_value(Unexpected::Bignum(v.as_ref()), &visitor)),
-                    IntVisitorValue::BignumRef(v) => v.$to_primitive().ok_or(Error::invalid_value(Unexpected::Bignum(v), &visitor)),
-                }
+                deserializer.deserialize(IntVisitor::<'de, $primitive>(PhantomData))
             }
         })*
     };
 }
 
-#[derive(Clone, Copy)]
+primitive_int_impl! {
+    u8,
+    u16,
+    u32,
+    u64,
+    u128,
+    usize,
+    i8,
+    i16,
+    i32,
+    i64,
+    i128,
+    isize,
+}
+
 struct NonZeroIntVisitor<'de, T>(PhantomData<&'de T>);
 
 impl<'de, T> Visitor<'de> for NonZeroIntVisitor<'de, T>
 where
-    T: std::fmt::Display + num_traits::Bounded,
+    T: std::fmt::Display + num_traits::Bounded + NumCast,
 {
-    type Value = IntVisitorValue<'de>;
+    type Value = T;
 
     fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let min = T::min_value();
@@ -116,77 +112,50 @@ where
     }
 
     fn visit_fixnum(self, v: Fixnum) -> Result<Self::Value> {
-        if v == 0i16.into() {
-            Err(Error::invalid_value(Unexpected::Fixnum(v), &self))
-        } else {
-            Ok(IntVisitorValue::Fixnum(v))
-        }
+        (v != 0i16.into())
+            .then(|| T::from(v))
+            .flatten()
+            .ok_or_else(|| Error::invalid_value(Unexpected::Fixnum(v), &self))
     }
 
     fn visit_bignum(self, v: BignumRef<'de>) -> Result<Self::Value> {
-        Ok(IntVisitorValue::BignumRef(v))
+        T::from(v).ok_or(Error::invalid_value(Unexpected::Bignum(v), &self))
     }
 
     fn visit_f64(self, v: f64) -> Result<Self::Value> {
-        if let Some(fixnum) = FromPrimitive::from_f64(v) {
-            self.visit_fixnum(fixnum)
-        } else {
-            Ok(IntVisitorValue::Bignum(FromPrimitive::from_f64(v).ok_or(
-                Error::invalid_value(Unexpected::Float(v), &self),
-            )?))
-        }
+        (v != 0.)
+            .then(|| T::from(v))
+            .flatten()
+            .ok_or_else(|| Error::invalid_value(Unexpected::Float(v), &self))
     }
 }
 
-primitive_int_impl!(
-    u8 => to_u8,
-    u16 => to_u16,
-    u32 => to_u32,
-    u64 => to_u64,
-    u128 => to_u128,
-    usize => to_usize,
-    i8 => to_i8,
-    i16 => to_i16,
-    i32 => to_i32,
-    i64 => to_i64,
-    i128 => to_i128,
-    isize => to_isize,
-);
-
 macro_rules! nonzero_int_impl {
-    ($($nonzero_primitive:ty | $primitive:ty => $to_primitive:ident),* $(,)?) => {
+    ($($primitive:ty => $nonzero_primitive:ty),* $(,)?) => {
         $(impl<'de> Deserialize<'de> for $nonzero_primitive {
             fn deserialize<D>(deserializer: D) -> Result<Self>
             where
                 D: DeserializerTrait<'de>,
             {
-                let visitor = NonZeroIntVisitor::<'de, $primitive>(PhantomData);
-                let i = match deserializer.deserialize(visitor)? {
-                    IntVisitorValue::Fixnum(v) => v.$to_primitive().ok_or(Error::invalid_value(Unexpected::Fixnum(v), &visitor)),
-                    IntVisitorValue::Bignum(v) => v.$to_primitive().ok_or(Error::invalid_value(Unexpected::Bignum(v.as_ref()), &visitor)),
-                    IntVisitorValue::BignumRef(v) => v.$to_primitive().ok_or(Error::invalid_value(Unexpected::Bignum(v), &visitor)),
-                }?;
-                // we've already asserted that it's non-zero simply by the fact that NonZeroIntVisitor returns a nonzero integer.
-                // so this new_unchecked is safe
-                Ok(unsafe { <$nonzero_primitive>::new_unchecked(i) })
+                Ok(deserializer.deserialize(IntVisitor::<'de, $primitive>(PhantomData))?.try_into().unwrap())
             }
         })*
     };
 }
 
 nonzero_int_impl!(
-    NonZeroU8 | u8 => to_u8,
-    NonZeroU16 | u16 => to_u16,
-    NonZeroU32 | u32 => to_u32,
-    NonZeroU64 | u64 => to_u64,
-    NonZeroU128 | u128 => to_u128,
-    NonZeroUsize | usize => to_usize,
-    NonZeroI8 | i8 => to_i8,
-    NonZeroI16 | i16 => to_i16,
-    NonZeroI32 | i32 => to_i32,
-    NonZeroI64 | i64 => to_i64,
-    NonZeroI128 | i128 => to_i128,
-    NonZeroIsize | isize => to_isize,
+    u8 => NonZeroU8,
+    u16 => NonZeroU16,
+    u32 => NonZeroU32,
+    u64 => NonZeroU64,
+    u128 => NonZeroU128,
+    usize => NonZeroUsize,
+    i8 => NonZeroI8,
+    i16 => NonZeroI16,
+    i32 => NonZeroI32,
+    i64 => NonZeroI64,
+    i128 => NonZeroI128,
+    isize => NonZeroIsize,
 );
 
 struct UnitVisitor;

--- a/alox-48/src/de/impls.rs
+++ b/alox-48/src/de/impls.rs
@@ -20,7 +20,7 @@ use super::{
     traits::VisitorOption, ArrayAccess, Deserialize, DeserializeSeed, DeserializerTrait, Error,
     HashAccess, Kind, Result, Unexpected, Visitor,
 };
-use crate::Sym;
+use crate::{Bignum, BignumRef, Fixnum, Sym};
 
 impl<'de, T> DeserializeSeed<'de> for PhantomData<T>
 where
@@ -36,112 +36,141 @@ where
     }
 }
 
-struct IntVisitor;
+struct IntVisitor<'de>(PhantomData<&'de ()>);
 
-impl Visitor<'_> for IntVisitor {
-    type Value = num_bigint::BigInt;
+enum IntVisitorValue<'de> {
+    Fixnum(Fixnum),
+    Bignum(Bignum),
+    BignumRef(BignumRef<'de>),
+}
+
+impl<'de> Visitor<'de> for IntVisitor<'de> {
+    type Value = IntVisitorValue<'de>;
 
     fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         formatter.write_str("an integer")
     }
 
-    fn visit_bignum(self, v: num_bigint::BigInt) -> Result<Self::Value> {
-        Ok(v)
+    fn visit_fixnum(self, v: Fixnum) -> Result<Self::Value> {
+        Ok(IntVisitorValue::Fixnum(v))
+    }
+
+    fn visit_bignum(self, v: BignumRef<'de>) -> Result<Self::Value> {
+        Ok(IntVisitorValue::BignumRef(v))
     }
 
     fn visit_f64(self, v: f64) -> Result<Self::Value> {
-        use num_traits::FromPrimitive;
-        num_bigint::BigInt::from_f64(v).ok_or(Error {
-            kind: Kind::InvalidFloatToIntConversion,
-        })
+        if let Some(fixnum) = num_traits::FromPrimitive::from_f64(v) {
+            self.visit_fixnum(fixnum)
+        } else {
+            Ok(IntVisitorValue::Bignum(
+                num_traits::FromPrimitive::from_f64(v).ok_or(Error {
+                    kind: Kind::InvalidFloatToIntConversion,
+                })?,
+            ))
+        }
     }
 }
 
 macro_rules! primitive_int_impl {
-    ($($primitive:ty),*) => {
+    ($($primitive:ty => $to_primitive:ident),* $(,)?) => {
         $(impl<'de> Deserialize<'de> for $primitive {
             fn deserialize<D>(deserializer: D) -> Result<Self>
             where
                 D: DeserializerTrait<'de>,
             {
-                let i = deserializer.deserialize(IntVisitor)?;
-                i.try_into().map_err(|_| Error { kind: Kind::NumericOverflow })
+                match deserializer.deserialize(IntVisitor(Default::default()))? {
+                    IntVisitorValue::Fixnum(v) => num_traits::ToPrimitive::$to_primitive(&v).ok_or(Error { kind: Kind::NumericOverflow }),
+                    IntVisitorValue::Bignum(v) => num_traits::ToPrimitive::$to_primitive(&v).ok_or(Error { kind: Kind::NumericOverflow }),
+                    IntVisitorValue::BignumRef(v) => num_traits::ToPrimitive::$to_primitive(&v).ok_or(Error { kind: Kind::NumericOverflow }),
+                }
             }
         })*
     };
 }
 
-struct NonZeroIntVisitor;
+struct NonZeroIntVisitor<'de>(PhantomData<&'de ()>);
 
-impl Visitor<'_> for NonZeroIntVisitor {
-    type Value = num_bigint::BigInt;
+impl<'de> Visitor<'de> for NonZeroIntVisitor<'de> {
+    type Value = IntVisitorValue<'de>;
 
     fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         formatter.write_str("a non-zero integer")
     }
 
-    fn visit_bignum(self, v: num_bigint::BigInt) -> Result<Self::Value> {
-        if v == num_bigint::BigInt::ZERO {
-            Err(Error::invalid_value(Unexpected::Integer(&v), &self))
+    fn visit_fixnum(self, v: Fixnum) -> Result<Self::Value> {
+        if v == 0i16.into() {
+            Err(Error::invalid_value(Unexpected::Fixnum(v), &self))
         } else {
-            Ok(v)
+            Ok(IntVisitorValue::Fixnum(v))
         }
     }
 
+    fn visit_bignum(self, v: BignumRef<'de>) -> Result<Self::Value> {
+        Ok(IntVisitorValue::BignumRef(v))
+    }
+
     fn visit_f64(self, v: f64) -> Result<Self::Value> {
-        use num_traits::FromPrimitive;
-        self.visit_bignum(num_bigint::BigInt::from_f64(v).ok_or(Error {
-            kind: Kind::InvalidFloatToIntConversion,
-        })?)
+        if let Some(fixnum) = num_traits::FromPrimitive::from_f64(v) {
+            self.visit_fixnum(fixnum)
+        } else {
+            Ok(IntVisitorValue::Bignum(
+                num_traits::FromPrimitive::from_f64(v).ok_or(Error {
+                    kind: Kind::InvalidFloatToIntConversion,
+                })?,
+            ))
+        }
     }
 }
 
 primitive_int_impl!(
-    u8,
-    u16,
-    u32,
-    u64,
-    u128,
-    usize,
-    num_bigint::BigUint,
-    i8,
-    i16,
-    i32,
-    i64,
-    i128,
-    isize,
-    num_bigint::BigInt
+    u8 => to_u8,
+    u16 => to_u16,
+    u32 => to_u32,
+    u64 => to_u64,
+    u128 => to_u128,
+    usize => to_usize,
+    i8 => to_i8,
+    i16 => to_i16,
+    i32 => to_i32,
+    i64 => to_i64,
+    i128 => to_i128,
+    isize => to_isize,
 );
 
 macro_rules! nonzero_int_impl {
-    ($($primitive:ty),*) => {
+    ($($primitive:ty => $to_primitive:ident),* $(,)?) => {
         $(impl<'de> Deserialize<'de> for $primitive {
             fn deserialize<D>(deserializer: D) -> Result<Self>
             where
                 D: DeserializerTrait<'de>,
             {
-                let i = deserializer.deserialize(NonZeroIntVisitor)?;
+                let i = match deserializer.deserialize(NonZeroIntVisitor(Default::default()))? {
+                    IntVisitorValue::Fixnum(v) => num_traits::ToPrimitive::$to_primitive(&v).ok_or(Error { kind: Kind::NumericOverflow }),
+                    IntVisitorValue::Bignum(v) => num_traits::ToPrimitive::$to_primitive(&v).ok_or(Error { kind: Kind::NumericOverflow }),
+                    IntVisitorValue::BignumRef(v) => num_traits::ToPrimitive::$to_primitive(&v).ok_or(Error { kind: Kind::NumericOverflow }),
+                }?;
                 // we've already asserted that it's non-zero simply by the fact that NonZeroIntVisitor returns a nonzero integer.
                 // so this new_unchecked is safe
-                Ok(unsafe { <$primitive>::new_unchecked(i.try_into().map_err(|_| Error { kind: Kind::NumericOverflow })?) })
+                Ok(unsafe { <$primitive>::new_unchecked(i) })
             }
         })*
     };
 }
 
 nonzero_int_impl!(
-    NonZeroU8,
-    NonZeroU16,
-    NonZeroU32,
-    NonZeroU64,
-    NonZeroU128,
-    NonZeroUsize,
-    NonZeroI8,
-    NonZeroI16,
-    NonZeroI32,
-    NonZeroI64,
-    NonZeroI128,
-    NonZeroIsize
+    NonZeroU8 => to_u8,
+    NonZeroU16 => to_u16,
+    NonZeroU32 => to_u32,
+    NonZeroU64 => to_u64,
+    NonZeroU128 => to_u128,
+    NonZeroUsize => to_usize,
+    NonZeroI8 => to_i8,
+    NonZeroI16 => to_i16,
+    NonZeroI32 => to_i32,
+    NonZeroI64 => to_i64,
+    NonZeroI128 => to_i128,
+    NonZeroIsize => to_isize,
 );
 
 struct UnitVisitor;
@@ -199,9 +228,14 @@ impl Visitor<'_> for FloatVisitor {
         formatter.write_str("a float")
     }
 
-    fn visit_bignum(self, v: num_bigint::BigInt) -> Result<Self::Value> {
-        use num_traits::ToPrimitive;
-        v.to_f64().ok_or(Error {
+    fn visit_fixnum(self, v: Fixnum) -> Result<Self::Value> {
+        num_traits::ToPrimitive::to_f64(&v).ok_or(Error {
+            kind: Kind::NumericOverflow,
+        })
+    }
+
+    fn visit_bignum(self, v: BignumRef<'_>) -> Result<Self::Value> {
+        num_traits::ToPrimitive::to_f64(&v).ok_or(Error {
             kind: Kind::NumericOverflow,
         })
     }

--- a/alox-48/src/de/impls.rs
+++ b/alox-48/src/de/impls.rs
@@ -18,7 +18,7 @@ use std::{
 
 use super::{
     traits::VisitorOption, ArrayAccess, Deserialize, DeserializeSeed, DeserializerTrait, Error,
-    HashAccess, Kind, Result, Unexpected, Visitor,
+    HashAccess, Result, Unexpected, Visitor,
 };
 use crate::{Bignum, BignumRef, Fixnum, Sym};
 
@@ -36,7 +36,8 @@ where
     }
 }
 
-struct IntVisitor<'de>(PhantomData<&'de ()>);
+#[derive(Clone, Copy)]
+struct IntVisitor<'de, T>(PhantomData<&'de T>);
 
 enum IntVisitorValue<'de> {
     Fixnum(Fixnum),
@@ -44,11 +45,19 @@ enum IntVisitorValue<'de> {
     BignumRef(BignumRef<'de>),
 }
 
-impl<'de> Visitor<'de> for IntVisitor<'de> {
+impl<'de, T> Visitor<'de> for IntVisitor<'de, T>
+where
+    T: std::fmt::Display + num_traits::Bounded,
+{
     type Value = IntVisitorValue<'de>;
 
     fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        formatter.write_str("an integer")
+        let min = T::min_value();
+        let max = T::max_value();
+        write!(
+            formatter,
+            "an integer in the range [{min}, {max}] or a finite float in the range [{min}, {max}]",
+        )
     }
 
     fn visit_fixnum(self, v: Fixnum) -> Result<Self::Value> {
@@ -64,9 +73,8 @@ impl<'de> Visitor<'de> for IntVisitor<'de> {
             self.visit_fixnum(fixnum)
         } else {
             Ok(IntVisitorValue::Bignum(
-                num_traits::FromPrimitive::from_f64(v).ok_or(Error {
-                    kind: Kind::InvalidFloatToIntConversion,
-                })?,
+                num_traits::FromPrimitive::from_f64(v)
+                    .ok_or(Error::invalid_value(Unexpected::Float(v), &self))?,
             ))
         }
     }
@@ -79,23 +87,33 @@ macro_rules! primitive_int_impl {
             where
                 D: DeserializerTrait<'de>,
             {
-                match deserializer.deserialize(IntVisitor(Default::default()))? {
-                    IntVisitorValue::Fixnum(v) => num_traits::ToPrimitive::$to_primitive(&v).ok_or(Error { kind: Kind::NumericOverflow }),
-                    IntVisitorValue::Bignum(v) => num_traits::ToPrimitive::$to_primitive(&v).ok_or(Error { kind: Kind::NumericOverflow }),
-                    IntVisitorValue::BignumRef(v) => num_traits::ToPrimitive::$to_primitive(&v).ok_or(Error { kind: Kind::NumericOverflow }),
+                let visitor = IntVisitor::<'de, $primitive>(PhantomData);
+                match deserializer.deserialize(visitor)? {
+                    IntVisitorValue::Fixnum(v) => num_traits::ToPrimitive::$to_primitive(&v).ok_or(Error::invalid_value(Unexpected::Fixnum(v), &visitor)),
+                    IntVisitorValue::Bignum(v) => num_traits::ToPrimitive::$to_primitive(&v).ok_or(Error::invalid_value(Unexpected::Bignum(v.as_ref()), &visitor)),
+                    IntVisitorValue::BignumRef(v) => num_traits::ToPrimitive::$to_primitive(&v).ok_or(Error::invalid_value(Unexpected::Bignum(v), &visitor)),
                 }
             }
         })*
     };
 }
 
-struct NonZeroIntVisitor<'de>(PhantomData<&'de ()>);
+#[derive(Clone, Copy)]
+struct NonZeroIntVisitor<'de, T>(PhantomData<&'de T>);
 
-impl<'de> Visitor<'de> for NonZeroIntVisitor<'de> {
+impl<'de, T> Visitor<'de> for NonZeroIntVisitor<'de, T>
+where
+    T: std::fmt::Display + num_traits::Bounded,
+{
     type Value = IntVisitorValue<'de>;
 
     fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        formatter.write_str("a non-zero integer")
+        let min = T::min_value();
+        let max = T::max_value();
+        write!(
+            formatter,
+            "a nonzero integer in the range [{min}, {max}] or a nonzero finite float in the range [{min}, {max}]",
+        )
     }
 
     fn visit_fixnum(self, v: Fixnum) -> Result<Self::Value> {
@@ -115,9 +133,8 @@ impl<'de> Visitor<'de> for NonZeroIntVisitor<'de> {
             self.visit_fixnum(fixnum)
         } else {
             Ok(IntVisitorValue::Bignum(
-                num_traits::FromPrimitive::from_f64(v).ok_or(Error {
-                    kind: Kind::InvalidFloatToIntConversion,
-                })?,
+                num_traits::FromPrimitive::from_f64(v)
+                    .ok_or(Error::invalid_value(Unexpected::Float(v), &self))?,
             ))
         }
     }
@@ -139,38 +156,39 @@ primitive_int_impl!(
 );
 
 macro_rules! nonzero_int_impl {
-    ($($primitive:ty => $to_primitive:ident),* $(,)?) => {
-        $(impl<'de> Deserialize<'de> for $primitive {
+    ($($nonzero_primitive:ty | $primitive:ty => $to_primitive:ident),* $(,)?) => {
+        $(impl<'de> Deserialize<'de> for $nonzero_primitive {
             fn deserialize<D>(deserializer: D) -> Result<Self>
             where
                 D: DeserializerTrait<'de>,
             {
-                let i = match deserializer.deserialize(NonZeroIntVisitor(Default::default()))? {
-                    IntVisitorValue::Fixnum(v) => num_traits::ToPrimitive::$to_primitive(&v).ok_or(Error { kind: Kind::NumericOverflow }),
-                    IntVisitorValue::Bignum(v) => num_traits::ToPrimitive::$to_primitive(&v).ok_or(Error { kind: Kind::NumericOverflow }),
-                    IntVisitorValue::BignumRef(v) => num_traits::ToPrimitive::$to_primitive(&v).ok_or(Error { kind: Kind::NumericOverflow }),
+                let visitor = NonZeroIntVisitor::<'de, $primitive>(PhantomData);
+                let i = match deserializer.deserialize(visitor)? {
+                    IntVisitorValue::Fixnum(v) => num_traits::ToPrimitive::$to_primitive(&v).ok_or(Error::invalid_value(Unexpected::Fixnum(v), &visitor)),
+                    IntVisitorValue::Bignum(v) => num_traits::ToPrimitive::$to_primitive(&v).ok_or(Error::invalid_value(Unexpected::Bignum(v.as_ref()), &visitor)),
+                    IntVisitorValue::BignumRef(v) => num_traits::ToPrimitive::$to_primitive(&v).ok_or(Error::invalid_value(Unexpected::Bignum(v), &visitor)),
                 }?;
                 // we've already asserted that it's non-zero simply by the fact that NonZeroIntVisitor returns a nonzero integer.
                 // so this new_unchecked is safe
-                Ok(unsafe { <$primitive>::new_unchecked(i) })
+                Ok(unsafe { <$nonzero_primitive>::new_unchecked(i) })
             }
         })*
     };
 }
 
 nonzero_int_impl!(
-    NonZeroU8 => to_u8,
-    NonZeroU16 => to_u16,
-    NonZeroU32 => to_u32,
-    NonZeroU64 => to_u64,
-    NonZeroU128 => to_u128,
-    NonZeroUsize => to_usize,
-    NonZeroI8 => to_i8,
-    NonZeroI16 => to_i16,
-    NonZeroI32 => to_i32,
-    NonZeroI64 => to_i64,
-    NonZeroI128 => to_i128,
-    NonZeroIsize => to_isize,
+    NonZeroU8 | u8 => to_u8,
+    NonZeroU16 | u16 => to_u16,
+    NonZeroU32 | u32 => to_u32,
+    NonZeroU64 | u64 => to_u64,
+    NonZeroU128 | u128 => to_u128,
+    NonZeroUsize | usize => to_usize,
+    NonZeroI8 | i8 => to_i8,
+    NonZeroI16 | i16 => to_i16,
+    NonZeroI32 | i32 => to_i32,
+    NonZeroI64 | i64 => to_i64,
+    NonZeroI128 | i128 => to_i128,
+    NonZeroIsize | isize => to_isize,
 );
 
 struct UnitVisitor;
@@ -225,19 +243,17 @@ impl Visitor<'_> for FloatVisitor {
     type Value = f64;
 
     fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        formatter.write_str("a float")
+        formatter.write_str("a float or integer")
     }
 
     fn visit_fixnum(self, v: Fixnum) -> Result<Self::Value> {
-        num_traits::ToPrimitive::to_f64(&v).ok_or(Error {
-            kind: Kind::NumericOverflow,
-        })
+        num_traits::ToPrimitive::to_f64(&v)
+            .ok_or(Error::invalid_value(Unexpected::Fixnum(v), &self))
     }
 
     fn visit_bignum(self, v: BignumRef<'_>) -> Result<Self::Value> {
-        num_traits::ToPrimitive::to_f64(&v).ok_or(Error {
-            kind: Kind::NumericOverflow,
-        })
+        num_traits::ToPrimitive::to_f64(&v)
+            .ok_or(Error::invalid_value(Unexpected::Bignum(v), &self))
     }
 
     fn visit_f64(self, v: f64) -> Result<Self::Value> {

--- a/alox-48/src/de/traits.rs
+++ b/alox-48/src/de/traits.rs
@@ -67,11 +67,11 @@ pub trait Visitor<'de>: Sized {
     fn visit_bool(self, v: bool) -> Result<Self::Value> {
         Err(Error::invalid_value(Unexpected::Bool(v), &self))
     }
-    /// Input contains an integer value within the interval $[-2^30, 2^30)$.
+    /// Input contains an integer value within the interval [-2<sup>30</sup>, 2<sup>30</sup>).
     fn visit_fixnum(self, v: Fixnum) -> Result<Self::Value> {
         Err(Error::invalid_value(Unexpected::Fixnum(v), &self))
     }
-    /// Input contains an integer value outside of the interval $[-2^30, 2^30)$.
+    /// Input contains an integer value outside of the interval [-2<sup>30</sup>, 2<sup>30</sup>).
     fn visit_bignum(self, v: BignumRef<'de>) -> Result<Self::Value> {
         Err(Error::invalid_value(Unexpected::Bignum(v), &self))
     }

--- a/alox-48/src/de/traits.rs
+++ b/alox-48/src/de/traits.rs
@@ -68,8 +68,8 @@ pub trait Visitor<'de>: Sized {
         Err(Error::invalid_value(Unexpected::Bool(v), &self))
     }
     /// Input contains an integer value.
-    fn visit_i32(self, v: i32) -> Result<Self::Value> {
-        Err(Error::invalid_value(Unexpected::Integer(v), &self))
+    fn visit_bignum(self, v: num_bigint::BigInt) -> Result<Self::Value> {
+        Err(Error::invalid_value(Unexpected::Integer(&v), &self))
     }
     /// Input contains a float value.
     fn visit_f64(self, v: f64) -> Result<Self::Value> {

--- a/alox-48/src/de/traits.rs
+++ b/alox-48/src/de/traits.rs
@@ -4,7 +4,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 use super::{error::Unexpected, Error, Result};
-use crate::Sym;
+use crate::{BignumRef, Fixnum, Sym};
 use std::marker::PhantomData;
 
 /// A structure that can be deserialized from ruby marshal format.
@@ -67,9 +67,13 @@ pub trait Visitor<'de>: Sized {
     fn visit_bool(self, v: bool) -> Result<Self::Value> {
         Err(Error::invalid_value(Unexpected::Bool(v), &self))
     }
-    /// Input contains an integer value.
-    fn visit_bignum(self, v: num_bigint::BigInt) -> Result<Self::Value> {
-        Err(Error::invalid_value(Unexpected::Integer(&v), &self))
+    /// Input contains an integer value within the interval $[-2^30, 2^30)$.
+    fn visit_fixnum(self, v: Fixnum) -> Result<Self::Value> {
+        Err(Error::invalid_value(Unexpected::Fixnum(v), &self))
+    }
+    /// Input contains an integer value outside of the interval $[-2^30, 2^30)$.
+    fn visit_bignum(self, v: BignumRef<'de>) -> Result<Self::Value> {
+        Err(Error::invalid_value(Unexpected::Bignum(v), &self))
     }
     /// Input contains a float value.
     fn visit_f64(self, v: f64) -> Result<Self::Value> {

--- a/alox-48/src/lib.rs
+++ b/alox-48/src/lib.rs
@@ -141,8 +141,30 @@ mod ints {
     }
 
     #[test]
+    fn round_trip_bignum_positive() {
+        let int = 12345678987654321i64;
+
+        let bytes = crate::to_bytes(int).unwrap();
+
+        let int2 = crate::from_bytes(&bytes).unwrap();
+
+        assert_eq!(int, int2);
+    }
+
+    #[test]
+    fn round_trip_bignum_negative() {
+        let int = -12345678987654321i64;
+
+        let bytes = crate::to_bytes(int).unwrap();
+
+        let int2 = crate::from_bytes(&bytes).unwrap();
+
+        assert_eq!(int, int2);
+    }
+
+    #[test]
     fn round_trip_value() {
-        let value = crate::Value::Integer(123);
+        let value = crate::Value::Integer(123.into());
 
         let bytes = crate::to_bytes(&value).unwrap();
 
@@ -455,7 +477,7 @@ mod value_test {
         let instance = obj.into_instance().unwrap();
 
         assert_eq!(instance.value.as_ref(), "hello!");
-        assert_eq!(instance.fields["@random"], 123);
+        assert_eq!(instance.fields["@random"], num_bigint::BigInt::from(123));
     }
 
     #[test]
@@ -471,7 +493,7 @@ mod value_test {
 
         let array = instance.value.as_array().unwrap();
         assert_eq!(&array[0], "test");
-        assert_eq!(array[1], 123);
+        assert_eq!(array[1], num_bigint::BigInt::from(123));
         assert_eq!(instance.fields["@ivar"], 5.0);
     }
 
@@ -545,7 +567,29 @@ mod round_trip {
 
     #[test]
     fn integer() {
-        let original = Value::Integer(123);
+        let original = Value::Integer(123.into());
+
+        let bytes = to_bytes(&original).unwrap();
+
+        let new: Value = from_bytes(&bytes).unwrap();
+
+        assert_eq!(original, new);
+    }
+
+    #[test]
+    fn integer_bignum() {
+        let original = Value::Integer(12345678987654321i64.into());
+
+        let bytes = to_bytes(&original).unwrap();
+
+        let new: Value = from_bytes(&bytes).unwrap();
+
+        assert_eq!(original, new);
+    }
+
+    #[test]
+    fn integer_bignum_negative() {
+        let original = Value::Integer((-12345678987654321i64).into());
 
         let bytes = to_bytes(&original).unwrap();
 
@@ -578,7 +622,7 @@ mod round_trip {
 
     #[test]
     fn array() {
-        let original = Value::Array(vec![Value::Integer(1), Value::Float(256.652)]);
+        let original = Value::Array(vec![Value::Integer(1.into()), Value::Float(256.652)]);
 
         let bytes = to_bytes(&original).unwrap();
 
@@ -590,7 +634,7 @@ mod round_trip {
     #[test]
     fn hash() {
         let mut hash = RbHash::new();
-        hash.insert(Value::Bool(true), Value::Integer(1));
+        hash.insert(Value::Bool(true), Value::Integer(1.into()));
         hash.insert(Value::Symbol("a_symbol".into()), Value::Float(256.652));
         let original = Value::Hash(hash);
 
@@ -640,7 +684,7 @@ mod round_trip {
         let inner_value = Box::new(Value::String("I've been round tripped, with ivars!".into()));
         let mut fields = RbFields::new();
         fields.insert("E".into(), Value::Bool(true));
-        fields.insert("@round_trip".into(), Value::Integer(123));
+        fields.insert("@round_trip".into(), Value::Integer(123.into()));
         let original = Value::Instance(Instance {
             value: inner_value,
             fields,

--- a/alox-48/src/lib.rs
+++ b/alox-48/src/lib.rs
@@ -407,11 +407,11 @@ mod bignum {
 
     #[test]
     fn f64_mantissa_overflow() {
-        let int = u64::MAX;
+        let int = u128::MAX;
 
-        let bignum = Bignum::from_u64(int).unwrap();
+        let bignum = Bignum::from_u128(int).unwrap();
 
-        assert_eq!(Some(1.8446744073709552e19), bignum.to_f64());
+        assert_eq!(Some(3.402823669209385e38), bignum.to_f64());
     }
 
     #[test]

--- a/alox-48/src/lib.rs
+++ b/alox-48/src/lib.rs
@@ -59,6 +59,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+pub use num_traits::{FromPrimitive, ToPrimitive};
+
 /// A convenience module for getting exact details about where an error occurred.
 pub mod path_to_error;
 
@@ -131,8 +133,7 @@ where
 
 #[cfg(test)]
 mod fixnum {
-    use crate::{int_to_le_bytes, Fixnum};
-    use num_traits::{FromPrimitive, ToPrimitive};
+    use crate::{int_to_le_bytes, Fixnum, FromPrimitive, ToPrimitive};
 
     #[test]
     fn i64_positive() {
@@ -258,8 +259,7 @@ mod fixnum {
 
 #[cfg(test)]
 mod bignum {
-    use crate::{int_to_le_bytes, Bignum};
-    use num_traits::{FromPrimitive, ToPrimitive};
+    use crate::{int_to_le_bytes, Bignum, FromPrimitive, ToPrimitive};
 
     #[test]
     fn i64_positive() {
@@ -962,7 +962,7 @@ mod value_test {
 
 #[cfg(test)]
 mod round_trip {
-    use crate::{from_bytes, to_bytes, Instance, RbFields, RbHash, RbStruct, Value};
+    use crate::{from_bytes, to_bytes, FromPrimitive, Instance, RbFields, RbHash, RbStruct, Value};
 
     #[test]
     fn nil() {
@@ -1010,8 +1010,7 @@ mod round_trip {
 
     #[test]
     fn integer_bignum_positive_even_length() {
-        let original =
-            Value::Bignum(num_traits::FromPrimitive::from_i64(0x1122334455667788).unwrap());
+        let original = Value::Bignum(FromPrimitive::from_i64(0x1122334455667788).unwrap());
 
         let bytes = to_bytes(&original).unwrap();
 
@@ -1022,8 +1021,7 @@ mod round_trip {
 
     #[test]
     fn integer_bignum_negative_even_length() {
-        let original =
-            Value::Bignum(num_traits::FromPrimitive::from_i64(-0x1122334455667788).unwrap());
+        let original = Value::Bignum(FromPrimitive::from_i64(-0x1122334455667788).unwrap());
 
         let bytes = to_bytes(&original).unwrap();
 
@@ -1034,8 +1032,7 @@ mod round_trip {
 
     #[test]
     fn integer_bignum_positive_odd_length() {
-        let original =
-            Value::Bignum(num_traits::FromPrimitive::from_i64(0x11223344556677).unwrap());
+        let original = Value::Bignum(FromPrimitive::from_i64(0x11223344556677).unwrap());
 
         let bytes = to_bytes(&original).unwrap();
 
@@ -1046,8 +1043,7 @@ mod round_trip {
 
     #[test]
     fn integer_bignum_negative_odd_length() {
-        let original =
-            Value::Bignum(num_traits::FromPrimitive::from_i64(-0x11223344556677).unwrap());
+        let original = Value::Bignum(FromPrimitive::from_i64(-0x11223344556677).unwrap());
 
         let bytes = to_bytes(&original).unwrap();
 

--- a/alox-48/src/lib.rs
+++ b/alox-48/src/lib.rs
@@ -75,7 +75,8 @@ pub use value::{from_value, to_value, Serializer as ValueSerializer, Value};
 mod rb_types;
 #[doc(inline)]
 pub use rb_types::{
-    Instance, Object, RbArray, RbFields, RbHash, RbString, RbStruct, Sym, Symbol, Userdata,
+    Bignum, BignumRef, Fixnum, Instance, Object, RbArray, RbFields, RbHash, RbString, RbStruct,
+    Sym, Symbol, Userdata,
 };
 
 #[doc(inline)]
@@ -116,6 +117,415 @@ where
     let mut serializer = Serializer::new();
     data.serialize(&mut serializer)?;
     Ok(serializer.output)
+}
+
+#[cfg(test)]
+fn int_to_le_bytes<T>(int: T) -> (bool, <T as num_traits::ToBytes>::Bytes)
+where
+    T: num_traits::ToBytes + num_traits::Signed + num_traits::WrappingNeg,
+{
+    let is_negative = int.is_negative();
+    let le_bytes = if is_negative { int.wrapping_neg() } else { int }.to_le_bytes();
+    (is_negative, le_bytes)
+}
+
+#[cfg(test)]
+mod fixnum {
+    use crate::{int_to_le_bytes, Fixnum};
+    use num_traits::{FromPrimitive, ToPrimitive};
+
+    #[test]
+    fn i64_positive() {
+        let int: i64 = 0x3fffffff;
+
+        let fixnum = Fixnum::from_i64(int).unwrap();
+
+        assert_eq!(int, fixnum.into())
+    }
+
+    #[test]
+    fn i64_negative() {
+        let int: i64 = -0x40000000;
+
+        let fixnum = Fixnum::from_i64(int).unwrap();
+
+        assert_eq!(int, fixnum.into())
+    }
+
+    #[test]
+    fn u64() {
+        let int: u64 = 0x3fffffff;
+
+        let fixnum = Fixnum::from_u64(int).unwrap();
+
+        assert_eq!(Some(int), fixnum.to_u64())
+    }
+
+    #[test]
+    fn from_le_bytes_positive() {
+        let int: i64 = 0x3fffffff;
+        let (is_negative, le_bytes) = int_to_le_bytes(int);
+
+        let fixnum = Fixnum::from_le_bytes(is_negative, &le_bytes).unwrap();
+
+        assert_eq!(int, fixnum.into());
+    }
+
+    #[test]
+    fn from_le_bytes_negative() {
+        let int: i64 = -0x40000000;
+        let (is_negative, le_bytes) = int_to_le_bytes(int);
+
+        let fixnum = Fixnum::from_le_bytes(is_negative, &le_bytes).unwrap();
+
+        assert_eq!(int, fixnum.into());
+    }
+
+    #[test]
+    fn i64_positive_out_of_range() {
+        let int: i64 = 0x40000000;
+
+        assert!(Fixnum::from_i64(int).is_none());
+    }
+
+    #[test]
+    fn i64_negative_out_of_range() {
+        let int: i64 = -0x40000001;
+
+        assert!(Fixnum::from_i64(int).is_none());
+    }
+
+    #[test]
+    fn u64_out_of_range() {
+        let int: u64 = 0x40000000;
+
+        assert!(Fixnum::from_u64(int).is_none());
+    }
+
+    #[test]
+    fn from_le_bytes_positive_out_of_range() {
+        let int: i64 = 0x40000000;
+        let (is_negative, le_bytes) = int_to_le_bytes(int);
+
+        assert!(Fixnum::from_le_bytes(is_negative, &le_bytes).is_none());
+    }
+
+    #[test]
+    fn from_le_bytes_negative_out_of_range() {
+        let int: i64 = -0x40000001;
+        let (is_negative, le_bytes) = int_to_le_bytes(int);
+
+        assert!(Fixnum::from_le_bytes(is_negative, &le_bytes).is_none());
+    }
+
+    #[test]
+    fn i64_max() {
+        let int = i64::MAX;
+
+        assert!(Fixnum::from_i64(int).is_none());
+    }
+
+    #[test]
+    fn i64_min() {
+        let int = i64::MIN;
+
+        assert!(Fixnum::from_i64(int).is_none());
+    }
+
+    #[test]
+    fn u64_max() {
+        let int = u64::MAX;
+
+        assert!(Fixnum::from_u64(int).is_none());
+    }
+
+    #[test]
+    fn from_le_bytes_max() {
+        let int = i64::MAX;
+        let (is_negative, le_bytes) = int_to_le_bytes(int);
+
+        assert!(Fixnum::from_le_bytes(is_negative, &le_bytes).is_none());
+    }
+
+    #[test]
+    fn from_le_bytes_min() {
+        let int = i64::MIN;
+        let (is_negative, le_bytes) = int_to_le_bytes(int);
+
+        assert!(Fixnum::from_le_bytes(is_negative, &le_bytes).is_none());
+    }
+}
+
+#[cfg(test)]
+mod bignum {
+    use crate::{int_to_le_bytes, Bignum};
+    use num_traits::{FromPrimitive, ToPrimitive};
+
+    #[test]
+    fn i64_positive() {
+        let int: i64 = 0x40000000;
+
+        let bignum = Bignum::from_i64(int).unwrap();
+
+        assert_eq!(Some(int), bignum.to_i64());
+    }
+
+    #[test]
+    fn i64_negative() {
+        let int: i64 = -0x40000001;
+
+        let bignum = Bignum::from_i64(int).unwrap();
+
+        assert_eq!(Some(int), bignum.to_i64());
+    }
+
+    #[test]
+    fn u64() {
+        let int: u64 = 0x40000000;
+
+        let bignum = Bignum::from_u64(int).unwrap();
+
+        assert_eq!(Some(int), bignum.to_u64());
+    }
+
+    #[test]
+    fn i64_max() {
+        let int = i64::MAX;
+
+        let bignum = Bignum::from_i64(int).unwrap();
+
+        assert_eq!(Some(int), bignum.to_i64());
+    }
+
+    #[test]
+    fn i64_min() {
+        let int = i64::MIN;
+
+        let bignum = Bignum::from_i64(int).unwrap();
+
+        assert_eq!(Some(int), bignum.to_i64());
+    }
+
+    #[test]
+    fn u64_max() {
+        let int = u64::MAX;
+
+        let bignum = Bignum::from_u64(int).unwrap();
+
+        assert_eq!(Some(int), bignum.to_u64());
+    }
+
+    #[test]
+    fn i128_positive() {
+        let int: i128 = 0x40000000;
+
+        let bignum = Bignum::from_i128(int).unwrap();
+
+        assert_eq!(Some(int), bignum.to_i128());
+    }
+
+    #[test]
+    fn i128_negative() {
+        let int: i128 = -0x40000001;
+
+        let bignum = Bignum::from_i128(int).unwrap();
+
+        assert_eq!(Some(int), bignum.to_i128());
+    }
+
+    #[test]
+    fn u128() {
+        let int: u128 = 0x40000000;
+
+        let bignum = Bignum::from_u128(int).unwrap();
+
+        assert_eq!(Some(int), bignum.to_u128());
+    }
+
+    #[test]
+    fn i128_max() {
+        let int = i128::MAX;
+
+        let bignum = Bignum::from_i128(int).unwrap();
+
+        assert_eq!(Some(int), bignum.to_i128());
+    }
+
+    #[test]
+    fn i128_min() {
+        let int = i128::MIN;
+
+        let bignum = Bignum::from_i128(int).unwrap();
+
+        assert_eq!(Some(int), bignum.to_i128());
+    }
+
+    #[test]
+    fn u128_max() {
+        let int = u128::MAX;
+
+        let bignum = Bignum::from_u128(int).unwrap();
+
+        assert_eq!(Some(int), bignum.to_u128());
+    }
+
+    #[test]
+    fn f64_positive() {
+        let int: f64 = 0x40000000 as _;
+
+        let bignum = Bignum::from_f64(int).unwrap();
+
+        assert_eq!(Some(int), bignum.to_f64());
+    }
+
+    #[test]
+    fn f64_negative() {
+        let int: f64 = -0x40000001 as _;
+
+        let bignum = Bignum::from_f64(int).unwrap();
+
+        assert_eq!(Some(int), bignum.to_f64());
+    }
+
+    #[test]
+    fn f64_max() {
+        let int = f64::MAX;
+
+        let bignum = Bignum::from_f64(int).unwrap();
+
+        assert_eq!(Some(int), bignum.to_f64());
+    }
+
+    #[test]
+    fn f64_min() {
+        let int = f64::MIN;
+
+        let bignum = Bignum::from_f64(int).unwrap();
+
+        assert_eq!(Some(int), bignum.to_f64());
+    }
+
+    #[test]
+    fn f64_mantissa_overflow() {
+        let int = u64::MAX;
+
+        let bignum = Bignum::from_u64(int).unwrap();
+
+        assert_eq!(Some(1.8446744073709552e19), bignum.to_f64());
+    }
+
+    #[test]
+    fn f64_infinity() {
+        let int = f64::INFINITY;
+
+        assert!(Bignum::from_f64(int).is_none());
+    }
+
+    #[test]
+    fn f64_neg_infinity() {
+        let int = f64::NEG_INFINITY;
+
+        assert!(Bignum::from_f64(int).is_none());
+    }
+
+    #[test]
+    fn f64_nan() {
+        let int = f64::NAN;
+
+        assert!(Bignum::from_f64(int).is_none());
+    }
+
+    #[test]
+    fn as_le_bytes_positive() {
+        let int: i128 = 0x4d3c2b1a;
+        let (is_negative, le_bytes) = int_to_le_bytes(int);
+
+        let bignum = Bignum::from_le_bytes(is_negative, le_bytes.to_vec()).unwrap();
+
+        let expected_is_negative = false;
+        let expected_le_bytes: &[_] = &[0x1a, 0x2b, 0x3c, 0x4d];
+
+        assert_eq!(
+            bignum.as_ref().as_le_bytes(),
+            (expected_is_negative, expected_le_bytes),
+        );
+        assert_eq!(
+            bignum.as_le_bytes(),
+            (expected_is_negative, expected_le_bytes),
+        );
+        assert_eq!(
+            bignum.to_le_bytes(),
+            (expected_is_negative, expected_le_bytes.to_vec()),
+        );
+    }
+
+    #[test]
+    fn as_le_bytes_negative() {
+        let int: i128 = -0x4d3c2b1a;
+        let (is_negative, le_bytes) = int_to_le_bytes(int);
+
+        let bignum = Bignum::from_le_bytes(is_negative, le_bytes.to_vec()).unwrap();
+
+        let expected_is_negative = true;
+        let expected_le_bytes: &[_] = &[0x1a, 0x2b, 0x3c, 0x4d];
+
+        assert_eq!(
+            bignum.as_ref().as_le_bytes(),
+            (expected_is_negative, expected_le_bytes),
+        );
+        assert_eq!(
+            bignum.as_le_bytes(),
+            (expected_is_negative, expected_le_bytes),
+        );
+        assert_eq!(
+            bignum.to_le_bytes(),
+            (expected_is_negative, expected_le_bytes.to_vec()),
+        );
+    }
+
+    #[test]
+    fn ord_differing_sign() {
+        let int1: i64 = -0xffffffffffff;
+        let int2: i64 = 0x0000ffffffff;
+
+        let bignum1 = Bignum::from_i64(int1);
+        let bignum2 = Bignum::from_i64(int2);
+
+        assert!(bignum1 < bignum2);
+    }
+
+    #[test]
+    fn ord_same_sign_differing_length() {
+        let int1: i64 = 0x0000ffffffff;
+        let int2: i64 = 0xffffffffffff;
+
+        let bignum1 = Bignum::from_i64(int1);
+        let bignum2 = Bignum::from_i64(int2);
+
+        assert!(bignum1 < bignum2);
+    }
+
+    #[test]
+    fn ord_same_sign_same_length() {
+        let int1: i64 = 0xfffffffffffe;
+        let int2: i64 = 0xffffffffffff;
+
+        let bignum1 = Bignum::from_i64(int1);
+        let bignum2 = Bignum::from_i64(int2);
+
+        assert!(bignum1 < bignum2);
+    }
+
+    #[test]
+    fn equality_differing_length() {
+        let int1: i64 = 0x40000000;
+        let int2: i128 = 0x40000000;
+
+        let bignum1 = Bignum::from_i64(int1);
+        let bignum2 = Bignum::from_i128(int2);
+
+        assert_eq!(bignum1, bignum2);
+    }
 }
 
 #[cfg(test)]

--- a/alox-48/src/lib.rs
+++ b/alox-48/src/lib.rs
@@ -574,7 +574,7 @@ mod ints {
 
     #[test]
     fn round_trip_value() {
-        let value = crate::Value::Integer(123.into());
+        let value = crate::Value::Fixnum(123i16.into());
 
         let bytes = crate::to_bytes(&value).unwrap();
 
@@ -887,7 +887,7 @@ mod value_test {
         let instance = obj.into_instance().unwrap();
 
         assert_eq!(instance.value.as_ref(), "hello!");
-        assert_eq!(instance.fields["@random"], num_bigint::BigInt::from(123));
+        assert_eq!(instance.fields["@random"], 123);
     }
 
     #[test]
@@ -903,7 +903,7 @@ mod value_test {
 
         let array = instance.value.as_array().unwrap();
         assert_eq!(&array[0], "test");
-        assert_eq!(array[1], num_bigint::BigInt::from(123));
+        assert_eq!(array[1], 123);
         assert_eq!(instance.fields["@ivar"], 5.0);
     }
 
@@ -977,7 +977,7 @@ mod round_trip {
 
     #[test]
     fn integer() {
-        let original = Value::Integer(123.into());
+        let original = Value::Fixnum(123i16.into());
 
         let bytes = to_bytes(&original).unwrap();
 
@@ -988,7 +988,8 @@ mod round_trip {
 
     #[test]
     fn integer_bignum() {
-        let original = Value::Integer(12345678987654321i64.into());
+        let original =
+            Value::Bignum(num_traits::FromPrimitive::from_i64(12345678987654321).unwrap());
 
         let bytes = to_bytes(&original).unwrap();
 
@@ -999,7 +1000,8 @@ mod round_trip {
 
     #[test]
     fn integer_bignum_negative() {
-        let original = Value::Integer((-12345678987654321i64).into());
+        let original =
+            Value::Bignum(num_traits::FromPrimitive::from_i64(12345678987654321).unwrap());
 
         let bytes = to_bytes(&original).unwrap();
 
@@ -1032,7 +1034,7 @@ mod round_trip {
 
     #[test]
     fn array() {
-        let original = Value::Array(vec![Value::Integer(1.into()), Value::Float(256.652)]);
+        let original = Value::Array(vec![Value::Fixnum(1i16.into()), Value::Float(256.652)]);
 
         let bytes = to_bytes(&original).unwrap();
 
@@ -1044,7 +1046,7 @@ mod round_trip {
     #[test]
     fn hash() {
         let mut hash = RbHash::new();
-        hash.insert(Value::Bool(true), Value::Integer(1.into()));
+        hash.insert(Value::Bool(true), Value::Fixnum(1i16.into()));
         hash.insert(Value::Symbol("a_symbol".into()), Value::Float(256.652));
         let original = Value::Hash(hash);
 
@@ -1094,7 +1096,7 @@ mod round_trip {
         let inner_value = Box::new(Value::String("I've been round tripped, with ivars!".into()));
         let mut fields = RbFields::new();
         fields.insert("E".into(), Value::Bool(true));
-        fields.insert("@round_trip".into(), Value::Integer(123.into()));
+        fields.insert("@round_trip".into(), Value::Fixnum(123i16.into()));
         let original = Value::Instance(Instance {
             value: inner_value,
             fields,

--- a/alox-48/src/lib.rs
+++ b/alox-48/src/lib.rs
@@ -59,7 +59,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-pub use num_traits::{FromPrimitive, ToPrimitive};
+pub use num_traits::{cast::cast, FromPrimitive, NumCast, ToPrimitive};
 
 /// A convenience module for getting exact details about where an error occurred.
 pub mod path_to_error;

--- a/alox-48/src/lib.rs
+++ b/alox-48/src/lib.rs
@@ -551,8 +551,8 @@ mod ints {
     }
 
     #[test]
-    fn round_trip_bignum_positive() {
-        let int = 12345678987654321i64;
+    fn round_trip_bignum_positive_even_length() {
+        let int: i64 = 0x1122334455667788;
 
         let bytes = crate::to_bytes(int).unwrap();
 
@@ -562,8 +562,30 @@ mod ints {
     }
 
     #[test]
-    fn round_trip_bignum_negative() {
-        let int = -12345678987654321i64;
+    fn round_trip_bignum_negative_even_length() {
+        let int: i64 = -0x1122334455667788;
+
+        let bytes = crate::to_bytes(int).unwrap();
+
+        let int2 = crate::from_bytes(&bytes).unwrap();
+
+        assert_eq!(int, int2);
+    }
+
+    #[test]
+    fn round_trip_bignum_positive_odd_length() {
+        let int: i64 = 0x11223344556677;
+
+        let bytes = crate::to_bytes(int).unwrap();
+
+        let int2 = crate::from_bytes(&bytes).unwrap();
+
+        assert_eq!(int, int2);
+    }
+
+    #[test]
+    fn round_trip_bignum_negative_odd_length() {
+        let int: i64 = -0x11223344556677;
 
         let bytes = crate::to_bytes(int).unwrap();
 
@@ -987,9 +1009,9 @@ mod round_trip {
     }
 
     #[test]
-    fn integer_bignum() {
+    fn integer_bignum_positive_even_length() {
         let original =
-            Value::Bignum(num_traits::FromPrimitive::from_i64(12345678987654321).unwrap());
+            Value::Bignum(num_traits::FromPrimitive::from_i64(0x1122334455667788).unwrap());
 
         let bytes = to_bytes(&original).unwrap();
 
@@ -999,9 +1021,33 @@ mod round_trip {
     }
 
     #[test]
-    fn integer_bignum_negative() {
+    fn integer_bignum_negative_even_length() {
         let original =
-            Value::Bignum(num_traits::FromPrimitive::from_i64(12345678987654321).unwrap());
+            Value::Bignum(num_traits::FromPrimitive::from_i64(-0x1122334455667788).unwrap());
+
+        let bytes = to_bytes(&original).unwrap();
+
+        let new: Value = from_bytes(&bytes).unwrap();
+
+        assert_eq!(original, new);
+    }
+
+    #[test]
+    fn integer_bignum_positive_odd_length() {
+        let original =
+            Value::Bignum(num_traits::FromPrimitive::from_i64(0x11223344556677).unwrap());
+
+        let bytes = to_bytes(&original).unwrap();
+
+        let new: Value = from_bytes(&bytes).unwrap();
+
+        assert_eq!(original, new);
+    }
+
+    #[test]
+    fn integer_bignum_negative_odd_length() {
+        let original =
+            Value::Bignum(num_traits::FromPrimitive::from_i64(-0x11223344556677).unwrap());
 
         let bytes = to_bytes(&original).unwrap();
 

--- a/alox-48/src/path_to_error/de.rs
+++ b/alox-48/src/path_to_error/de.rs
@@ -7,8 +7,8 @@
 use super::{add_context, Context, Trace};
 use crate::{
     de::{DeserializeSeed, DeserializerTrait},
-    ArrayAccess, DeResult, HashAccess, InstanceAccess, IvarAccess, Sym, Symbol, Visitor,
-    VisitorInstance, VisitorOption,
+    ArrayAccess, BignumRef, DeResult, Fixnum, HashAccess, InstanceAccess, IvarAccess, Sym, Symbol,
+    Visitor, VisitorInstance, VisitorOption,
 };
 
 /// A deserializer that tracks where errors occur.
@@ -90,10 +90,17 @@ where
         add_context!(self.inner.visit_bool(v), self.trace.push(Context::Bool(v)))
     }
 
-    fn visit_bignum(self, v: num_bigint::BigInt) -> DeResult<Self::Value> {
+    fn visit_fixnum(self, v: Fixnum) -> DeResult<Self::Value> {
         add_context!(
-            self.inner.visit_bignum(v.clone()),
-            self.trace.push(Context::Int(v))
+            self.inner.visit_fixnum(v),
+            self.trace.push(Context::Fixnum(v))
+        )
+    }
+
+    fn visit_bignum(self, v: BignumRef<'de>) -> DeResult<Self::Value> {
+        add_context!(
+            self.inner.visit_bignum(v),
+            self.trace.push(Context::Bignum(v.into()))
         )
     }
 

--- a/alox-48/src/path_to_error/de.rs
+++ b/alox-48/src/path_to_error/de.rs
@@ -90,8 +90,11 @@ where
         add_context!(self.inner.visit_bool(v), self.trace.push(Context::Bool(v)))
     }
 
-    fn visit_i32(self, v: i32) -> DeResult<Self::Value> {
-        add_context!(self.inner.visit_i32(v), self.trace.push(Context::Int(v)))
+    fn visit_bignum(self, v: num_bigint::BigInt) -> DeResult<Self::Value> {
+        add_context!(
+            self.inner.visit_bignum(v.clone()),
+            self.trace.push(Context::Int(v))
+        )
     }
 
     fn visit_f64(self, v: f64) -> DeResult<Self::Value> {

--- a/alox-48/src/path_to_error/mod.rs
+++ b/alox-48/src/path_to_error/mod.rs
@@ -35,7 +35,7 @@ pub enum Context {
     /// Error occurred while processing a boolean.
     Bool(bool),
     /// Error occurred while processing an integer.
-    Int(i32),
+    Int(num_bigint::BigInt),
     /// Error occurred while processing a float.
     Float(f64),
 

--- a/alox-48/src/path_to_error/mod.rs
+++ b/alox-48/src/path_to_error/mod.rs
@@ -4,7 +4,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 use crate::{
-    DeError, Deserialize, DeserializerTrait, SerError, Serialize, SerializerTrait, Symbol,
+    Bignum, DeError, Deserialize, DeserializerTrait, Fixnum, SerError, Serialize, SerializerTrait,
+    Symbol,
 };
 
 mod de;
@@ -34,8 +35,10 @@ pub enum Context {
     Nil,
     /// Error occurred while processing a boolean.
     Bool(bool),
-    /// Error occurred while processing an integer.
-    Int(num_bigint::BigInt),
+    /// Error occurred while processing a fixnum.
+    Fixnum(Fixnum),
+    /// Error occurred while processing a bignum.
+    Bignum(Bignum),
     /// Error occurred while processing a float.
     Float(f64),
 
@@ -188,14 +191,15 @@ impl std::fmt::Display for Trace {
 impl std::fmt::Display for Context {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         use Context::{
-            Array, ArrayIndex, Bool, Class, Data, Extended, FetchingField, Field, Float, Hash,
-            HashKey, HashValue, Instance, Int, Module, Nil, Object, Regex, String, Struct, Symbol,
-            UserClass, UserData, UserMarshal, WritingField, WritingFields,
+            Array, ArrayIndex, Bignum, Bool, Class, Data, Extended, FetchingField, Field, Fixnum,
+            Float, Hash, HashKey, HashValue, Instance, Module, Nil, Object, Regex, String, Struct,
+            Symbol, UserClass, UserData, UserMarshal, WritingField, WritingFields,
         };
         match self {
             Nil => write!(f, "while processing a nil"),
             Bool(v) => write!(f, "while processing a boolean: {v}"),
-            Int(v) => write!(f, "while processing an integer: {v}"),
+            Fixnum(v) => write!(f, "while processing a fixnum: {v}"),
+            Bignum(v) => write!(f, "while processing a bignum: {v}"),
             Float(v) => write!(f, "while processing a float: {v}"),
             Hash(len) => write!(f, "while processing a hash with {len} entries",),
             HashKey(index) => write!(f, "while processing the {index} key of a hash",),

--- a/alox-48/src/path_to_error/ser.rs
+++ b/alox-48/src/path_to_error/ser.rs
@@ -7,8 +7,8 @@ use std::cell::Cell;
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 use super::{add_context, Context, Trace};
 use crate::{
-    SerResult, Serialize, SerializeArray, SerializeHash, SerializeIvars, SerializerTrait, Sym,
-    Symbol,
+    BignumRef, Fixnum, SerResult, Serialize, SerializeArray, SerializeHash, SerializeIvars,
+    SerializerTrait, Sym, Symbol,
 };
 
 /// A serializer that tracks the path to an error.
@@ -83,10 +83,17 @@ where
         )
     }
 
-    fn serialize_bignum(self, v: num_bigint::BigInt) -> SerResult<Self::Ok> {
+    fn serialize_fixnum(self, v: Fixnum) -> SerResult<Self::Ok> {
         add_context!(
-            self.serializer.serialize_bignum(v.clone()),
-            self.trace.push(Context::Int(v))
+            self.serializer.serialize_fixnum(v),
+            self.trace.push(Context::Fixnum(v))
+        )
+    }
+
+    fn serialize_bignum(self, v: BignumRef<'_>) -> SerResult<Self::Ok> {
+        add_context!(
+            self.serializer.serialize_bignum(v),
+            self.trace.push(Context::Bignum(v.into()))
         )
     }
 

--- a/alox-48/src/path_to_error/ser.rs
+++ b/alox-48/src/path_to_error/ser.rs
@@ -83,9 +83,9 @@ where
         )
     }
 
-    fn serialize_i32(self, v: i32) -> SerResult<Self::Ok> {
+    fn serialize_bignum(self, v: num_bigint::BigInt) -> SerResult<Self::Ok> {
         add_context!(
-            self.serializer.serialize_i32(v),
+            self.serializer.serialize_bignum(v.clone()),
             self.trace.push(Context::Int(v))
         )
     }

--- a/alox-48/src/rb_types/bignum.rs
+++ b/alox-48/src/rb_types/bignum.rs
@@ -180,16 +180,7 @@ impl num_traits::ToPrimitive for BignumRef<'_> {
     fn to_i64(&self) -> Option<i64> {
         (self.le_bytes.len() <= size_of::<i64>())
             .then(|| {
-                let value = i64::from_le_bytes([
-                    self.le_bytes.first().copied().unwrap_or_default(),
-                    self.le_bytes.get(1).copied().unwrap_or_default(),
-                    self.le_bytes.get(2).copied().unwrap_or_default(),
-                    self.le_bytes.get(3).copied().unwrap_or_default(),
-                    self.le_bytes.get(4).copied().unwrap_or_default(),
-                    self.le_bytes.get(5).copied().unwrap_or_default(),
-                    self.le_bytes.get(6).copied().unwrap_or_default(),
-                    self.le_bytes.get(7).copied().unwrap_or_default(),
-                ]);
+                let value = i64::from_le_bytes(super::to_array_with_default(self.le_bytes));
                 let value = if self.is_negative {
                     value.wrapping_neg()
                 } else {
@@ -203,24 +194,7 @@ impl num_traits::ToPrimitive for BignumRef<'_> {
     fn to_i128(&self) -> Option<i128> {
         (self.le_bytes.len() <= size_of::<i128>())
             .then(|| {
-                let value = i128::from_le_bytes([
-                    self.le_bytes.first().copied().unwrap_or_default(),
-                    self.le_bytes.get(1).copied().unwrap_or_default(),
-                    self.le_bytes.get(2).copied().unwrap_or_default(),
-                    self.le_bytes.get(3).copied().unwrap_or_default(),
-                    self.le_bytes.get(4).copied().unwrap_or_default(),
-                    self.le_bytes.get(5).copied().unwrap_or_default(),
-                    self.le_bytes.get(6).copied().unwrap_or_default(),
-                    self.le_bytes.get(7).copied().unwrap_or_default(),
-                    self.le_bytes.get(8).copied().unwrap_or_default(),
-                    self.le_bytes.get(9).copied().unwrap_or_default(),
-                    self.le_bytes.get(10).copied().unwrap_or_default(),
-                    self.le_bytes.get(11).copied().unwrap_or_default(),
-                    self.le_bytes.get(12).copied().unwrap_or_default(),
-                    self.le_bytes.get(13).copied().unwrap_or_default(),
-                    self.le_bytes.get(14).copied().unwrap_or_default(),
-                    self.le_bytes.get(15).copied().unwrap_or_default(),
-                ]);
+                let value = i128::from_le_bytes(super::to_array_with_default(self.le_bytes));
                 let value = if self.is_negative {
                     value.wrapping_neg()
                 } else {
@@ -232,41 +206,13 @@ impl num_traits::ToPrimitive for BignumRef<'_> {
     }
 
     fn to_u64(&self) -> Option<u64> {
-        (!self.is_negative && self.le_bytes.len() <= size_of::<u64>()).then(|| {
-            u64::from_le_bytes([
-                self.le_bytes.first().copied().unwrap_or_default(),
-                self.le_bytes.get(1).copied().unwrap_or_default(),
-                self.le_bytes.get(2).copied().unwrap_or_default(),
-                self.le_bytes.get(3).copied().unwrap_or_default(),
-                self.le_bytes.get(4).copied().unwrap_or_default(),
-                self.le_bytes.get(5).copied().unwrap_or_default(),
-                self.le_bytes.get(6).copied().unwrap_or_default(),
-                self.le_bytes.get(7).copied().unwrap_or_default(),
-            ])
-        })
+        (!self.is_negative && self.le_bytes.len() <= size_of::<u64>())
+            .then(|| u64::from_le_bytes(super::to_array_with_default(self.le_bytes)))
     }
 
     fn to_u128(&self) -> Option<u128> {
-        (!self.is_negative && self.le_bytes.len() <= size_of::<u128>()).then(|| {
-            u128::from_le_bytes([
-                self.le_bytes.first().copied().unwrap_or_default(),
-                self.le_bytes.get(1).copied().unwrap_or_default(),
-                self.le_bytes.get(2).copied().unwrap_or_default(),
-                self.le_bytes.get(3).copied().unwrap_or_default(),
-                self.le_bytes.get(4).copied().unwrap_or_default(),
-                self.le_bytes.get(5).copied().unwrap_or_default(),
-                self.le_bytes.get(6).copied().unwrap_or_default(),
-                self.le_bytes.get(7).copied().unwrap_or_default(),
-                self.le_bytes.get(8).copied().unwrap_or_default(),
-                self.le_bytes.get(9).copied().unwrap_or_default(),
-                self.le_bytes.get(10).copied().unwrap_or_default(),
-                self.le_bytes.get(11).copied().unwrap_or_default(),
-                self.le_bytes.get(12).copied().unwrap_or_default(),
-                self.le_bytes.get(13).copied().unwrap_or_default(),
-                self.le_bytes.get(14).copied().unwrap_or_default(),
-                self.le_bytes.get(15).copied().unwrap_or_default(),
-            ])
-        })
+        (!self.is_negative && self.le_bytes.len() <= size_of::<u128>())
+            .then(|| u128::from_le_bytes(super::to_array_with_default(self.le_bytes)))
     }
 
     fn to_f64(&self) -> Option<f64> {
@@ -284,16 +230,7 @@ impl num_traits::ToPrimitive for BignumRef<'_> {
         let value_unsigned = if shift > (f64::MAX_EXP / 8).try_into().unwrap() {
             f64::INFINITY
         } else {
-            let mantissa = u64::from_le_bytes([
-                mantissa_le_bytes.first().copied().unwrap_or_default(),
-                mantissa_le_bytes.get(1).copied().unwrap_or_default(),
-                mantissa_le_bytes.get(2).copied().unwrap_or_default(),
-                mantissa_le_bytes.get(3).copied().unwrap_or_default(),
-                mantissa_le_bytes.get(4).copied().unwrap_or_default(),
-                mantissa_le_bytes.get(5).copied().unwrap_or_default(),
-                mantissa_le_bytes.get(6).copied().unwrap_or_default(),
-                mantissa_le_bytes.get(7).copied().unwrap_or_default(),
-            ]);
+            let mantissa = u64::from_le_bytes(super::to_array_with_default(mantissa_le_bytes));
             num_traits::ToPrimitive::to_f64(&mantissa).unwrap() * 2.0f64.powi(8 * shift as i32)
         };
         Some(if self.is_negative {

--- a/alox-48/src/rb_types/bignum.rs
+++ b/alox-48/src/rb_types/bignum.rs
@@ -261,6 +261,58 @@ impl NumCast for Bignum {
     }
 }
 
+macro_rules! try_from_impl {
+    ($($from:ty),* $(,)?) => {
+        $(impl TryFrom<$from> for Bignum {
+            type Error = $from;
+            fn try_from(value: $from) -> Result<Self, Self::Error> {
+                NumCast::from(value).ok_or(value)
+            }
+        })*
+    };
+}
+
+try_from_impl! {
+    i8,
+    u8,
+    i16,
+    u16,
+    i32,
+    u32,
+    i64,
+    u64,
+    i128,
+    u128,
+    isize,
+    usize,
+}
+
+macro_rules! try_into_impl {
+    ($($to:ty),* $(,)?) => {
+        $(impl<'a> TryFrom<BignumRef<'a>> for $to {
+            type Error = BignumRef<'a>;
+            fn try_from(value: BignumRef<'a>) -> Result<Self, Self::Error> {
+                NumCast::from(value).ok_or(value)
+            }
+        })*
+    };
+}
+
+try_into_impl! {
+    i8,
+    u8,
+    i16,
+    u16,
+    i32,
+    u32,
+    i64,
+    u64,
+    i128,
+    u128,
+    isize,
+    usize,
+}
+
 impl num_bigint::ToBigInt for BignumRef<'_> {
     fn to_bigint(&self) -> Option<num_bigint::BigInt> {
         Some(self.into())

--- a/alox-48/src/rb_types/bignum.rs
+++ b/alox-48/src/rb_types/bignum.rs
@@ -33,6 +33,15 @@ impl<'a> From<&'a Bignum> for BignumRef<'a> {
     }
 }
 
+impl<'a> From<BignumRef<'a>> for Bignum {
+    fn from(value: BignumRef<'a>) -> Self {
+        Self {
+            is_negative: value.is_negative,
+            le_bytes: value.le_bytes.to_vec(),
+        }
+    }
+}
+
 impl<'a> BignumRef<'a> {
     /// Attempts to create a new `BignumRef` from a sign and little-endian bytes.
     /// Will fail if the represented integer is within the interval $[-2^30, 2^30)$.

--- a/alox-48/src/rb_types/bignum.rs
+++ b/alox-48/src/rb_types/bignum.rs
@@ -1,0 +1,388 @@
+// Copyright (c) 2024 Lily Lyons
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/// A type representing a borrowed arbitrary-precision integer outside of the interval
+/// $[-2^30, 2^30)$.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct BignumRef<'a> {
+    /// True if the integer is less than zero, false if the integer is zero or greater than zero.
+    is_negative: bool,
+    /// Little-endian bytes of the integer with all trailing zero bytes removed.
+    le_bytes: &'a [u8],
+}
+
+/// A type representing an owned arbitrary-precision integer outside of the interval
+/// $[-2^30, 2^30)$.
+#[derive(Clone, PartialEq, Eq)]
+pub struct Bignum {
+    /// True if the integer is less than zero, false if the integer is zero or greater than zero.
+    is_negative: bool,
+    /// Little-endian bytes of the integer with all trailing zero bytes removed.
+    le_bytes: Vec<u8>,
+}
+
+impl<'a> From<&'a Bignum> for BignumRef<'a> {
+    fn from(value: &'a Bignum) -> Self {
+        Self {
+            is_negative: value.is_negative,
+            le_bytes: &value.le_bytes,
+        }
+    }
+}
+
+impl<'a> BignumRef<'a> {
+    /// Attempts to create a new `BignumRef` from a sign and little-endian bytes.
+    /// Will fail if the represented integer is within the interval $[-2^30, 2^30)$.
+    pub fn from_le_bytes(is_negative: bool, le_bytes: &'a [u8]) -> Option<Self> {
+        let le_bytes = &le_bytes[..super::get_le_bytes_size(le_bytes)];
+        let is_negative = if le_bytes.is_empty() {
+            false
+        } else {
+            is_negative
+        };
+        let value = Self {
+            is_negative,
+            le_bytes,
+        };
+        num_traits::ToPrimitive::to_i32(&value)
+            .is_none_or(|int| <crate::Fixnum as num_traits::FromPrimitive>::from_i32(int).is_none())
+            .then_some(value)
+    }
+
+    /// Returns the sign (true if negative, false if nonnegative) and little-endian bytes.
+    pub fn as_le_bytes(&self) -> (bool, &[u8]) {
+        (self.is_negative, self.le_bytes)
+    }
+}
+
+impl Bignum {
+    /// Attempts to create a new `Bignum` from a sign and little-endian bytes.
+    /// Will fail if the represented integer is within the interval $[-2^30, 2^30)$.
+    pub fn from_le_bytes(is_negative: bool, mut le_bytes: Vec<u8>) -> Option<Self> {
+        le_bytes.truncate(super::get_le_bytes_size(&le_bytes));
+        let is_negative = if le_bytes.is_empty() {
+            false
+        } else {
+            is_negative
+        };
+        let value = Self {
+            is_negative,
+            le_bytes,
+        };
+        num_traits::ToPrimitive::to_i32(&value)
+            .is_none_or(|int| <crate::Fixnum as num_traits::FromPrimitive>::from_i32(int).is_none())
+            .then_some(value)
+    }
+
+    /// Borrows this object as a `BignumRef`.
+    pub fn as_ref(&self) -> BignumRef<'_> {
+        self.into()
+    }
+
+    /// Returns the sign (true if negative, false if nonnegative) and little-endian bytes.
+    pub fn as_le_bytes(&self) -> (bool, &[u8]) {
+        (self.is_negative, &self.le_bytes)
+    }
+
+    /// Consumes this object, returning the sign (true if negative, false if nonnegative) and
+    /// little-endian bytes.
+    pub fn to_le_bytes(self) -> (bool, Vec<u8>) {
+        (self.is_negative, self.le_bytes)
+    }
+}
+
+impl<'a> From<BignumRef<'a>> for num_bigint::BigInt {
+    fn from(value: BignumRef<'a>) -> Self {
+        num_bigint::BigInt::from_bytes_le(
+            if value.is_negative {
+                num_bigint::Sign::Minus
+            } else {
+                num_bigint::Sign::Plus
+            },
+            value.le_bytes,
+        )
+    }
+}
+
+impl<'a> From<&BignumRef<'a>> for num_bigint::BigInt {
+    fn from(value: &BignumRef<'a>) -> Self {
+        (*value).into()
+    }
+}
+
+impl From<&Bignum> for num_bigint::BigInt {
+    fn from(value: &Bignum) -> Self {
+        value.as_ref().into()
+    }
+}
+
+impl num_traits::FromPrimitive for Bignum {
+    fn from_i64(n: i64) -> Option<Self> {
+        let le_bytes = n.wrapping_abs().to_le_bytes();
+        crate::Fixnum::from_i64(n).is_none().then(|| Self {
+            is_negative: n.is_negative(),
+            le_bytes: le_bytes[..super::get_le_bytes_size(&le_bytes)].to_vec(),
+        })
+    }
+
+    fn from_i128(n: i128) -> Option<Self> {
+        let le_bytes = n.wrapping_abs().to_le_bytes();
+        crate::Fixnum::from_i128(n).is_none().then(|| Self {
+            is_negative: n.is_negative(),
+            le_bytes: le_bytes[..super::get_le_bytes_size(&le_bytes)].to_vec(),
+        })
+    }
+
+    fn from_u64(n: u64) -> Option<Self> {
+        let le_bytes = n.to_le_bytes();
+        crate::Fixnum::from_u64(n).is_none().then(|| Self {
+            is_negative: false,
+            le_bytes: le_bytes[..super::get_le_bytes_size(&le_bytes)].to_vec(),
+        })
+    }
+
+    fn from_u128(n: u128) -> Option<Self> {
+        let le_bytes = n.to_le_bytes();
+        crate::Fixnum::from_u128(n).is_none().then(|| Self {
+            is_negative: false,
+            le_bytes: le_bytes[..super::get_le_bytes_size(&le_bytes)].to_vec(),
+        })
+    }
+
+    fn from_f64(n: f64) -> Option<Self> {
+        if !n.is_finite() {
+            return None;
+        }
+        let (mantissa, exponent, sign) = num_traits::Float::integer_decode(n);
+        let (padding_size, value) = if exponent > 0 {
+            (exponent / 8, mantissa << (exponent % 8))
+        } else {
+            (0, mantissa.unbounded_shr(-exponent as _))
+        };
+        let padding_size = padding_size as usize;
+        let mut le_bytes = Vec::with_capacity(padding_size + size_of::<u64>());
+        le_bytes.extend(std::iter::repeat_n(0, padding_size).chain(value.to_le_bytes()));
+        Self::from_le_bytes(sign < 0, le_bytes)
+    }
+}
+
+impl num_traits::ToPrimitive for BignumRef<'_> {
+    fn to_i64(&self) -> Option<i64> {
+        (self.le_bytes.len() <= size_of::<i64>())
+            .then(|| {
+                let value = i64::from_le_bytes([
+                    self.le_bytes.first().copied().unwrap_or_default(),
+                    self.le_bytes.get(1).copied().unwrap_or_default(),
+                    self.le_bytes.get(2).copied().unwrap_or_default(),
+                    self.le_bytes.get(3).copied().unwrap_or_default(),
+                    self.le_bytes.get(4).copied().unwrap_or_default(),
+                    self.le_bytes.get(5).copied().unwrap_or_default(),
+                    self.le_bytes.get(6).copied().unwrap_or_default(),
+                    self.le_bytes.get(7).copied().unwrap_or_default(),
+                ]);
+                let value = if self.is_negative {
+                    value.wrapping_neg()
+                } else {
+                    value
+                };
+                (value.is_negative() == self.is_negative).then_some(value)
+            })
+            .flatten()
+    }
+
+    fn to_i128(&self) -> Option<i128> {
+        (self.le_bytes.len() <= size_of::<i128>())
+            .then(|| {
+                let value = i128::from_le_bytes([
+                    self.le_bytes.first().copied().unwrap_or_default(),
+                    self.le_bytes.get(1).copied().unwrap_or_default(),
+                    self.le_bytes.get(2).copied().unwrap_or_default(),
+                    self.le_bytes.get(3).copied().unwrap_or_default(),
+                    self.le_bytes.get(4).copied().unwrap_or_default(),
+                    self.le_bytes.get(5).copied().unwrap_or_default(),
+                    self.le_bytes.get(6).copied().unwrap_or_default(),
+                    self.le_bytes.get(7).copied().unwrap_or_default(),
+                    self.le_bytes.get(8).copied().unwrap_or_default(),
+                    self.le_bytes.get(9).copied().unwrap_or_default(),
+                    self.le_bytes.get(10).copied().unwrap_or_default(),
+                    self.le_bytes.get(11).copied().unwrap_or_default(),
+                    self.le_bytes.get(12).copied().unwrap_or_default(),
+                    self.le_bytes.get(13).copied().unwrap_or_default(),
+                    self.le_bytes.get(14).copied().unwrap_or_default(),
+                    self.le_bytes.get(15).copied().unwrap_or_default(),
+                ]);
+                let value = if self.is_negative {
+                    value.wrapping_neg()
+                } else {
+                    value
+                };
+                (value.is_negative() == self.is_negative).then_some(value)
+            })
+            .flatten()
+    }
+
+    fn to_u64(&self) -> Option<u64> {
+        (!self.is_negative && self.le_bytes.len() <= size_of::<u64>()).then(|| {
+            u64::from_le_bytes([
+                self.le_bytes.first().copied().unwrap_or_default(),
+                self.le_bytes.get(1).copied().unwrap_or_default(),
+                self.le_bytes.get(2).copied().unwrap_or_default(),
+                self.le_bytes.get(3).copied().unwrap_or_default(),
+                self.le_bytes.get(4).copied().unwrap_or_default(),
+                self.le_bytes.get(5).copied().unwrap_or_default(),
+                self.le_bytes.get(6).copied().unwrap_or_default(),
+                self.le_bytes.get(7).copied().unwrap_or_default(),
+            ])
+        })
+    }
+
+    fn to_u128(&self) -> Option<u128> {
+        (!self.is_negative && self.le_bytes.len() <= size_of::<u128>()).then(|| {
+            u128::from_le_bytes([
+                self.le_bytes.first().copied().unwrap_or_default(),
+                self.le_bytes.get(1).copied().unwrap_or_default(),
+                self.le_bytes.get(2).copied().unwrap_or_default(),
+                self.le_bytes.get(3).copied().unwrap_or_default(),
+                self.le_bytes.get(4).copied().unwrap_or_default(),
+                self.le_bytes.get(5).copied().unwrap_or_default(),
+                self.le_bytes.get(6).copied().unwrap_or_default(),
+                self.le_bytes.get(7).copied().unwrap_or_default(),
+                self.le_bytes.get(8).copied().unwrap_or_default(),
+                self.le_bytes.get(9).copied().unwrap_or_default(),
+                self.le_bytes.get(10).copied().unwrap_or_default(),
+                self.le_bytes.get(11).copied().unwrap_or_default(),
+                self.le_bytes.get(12).copied().unwrap_or_default(),
+                self.le_bytes.get(13).copied().unwrap_or_default(),
+                self.le_bytes.get(14).copied().unwrap_or_default(),
+                self.le_bytes.get(15).copied().unwrap_or_default(),
+            ])
+        })
+    }
+
+    fn to_f64(&self) -> Option<f64> {
+        let mantissa_le_bytes =
+            &self.le_bytes[self.le_bytes.len().saturating_sub(size_of::<u64>())..];
+        let mut mantissa_first_nonzero_byte_index = 0;
+        for (i, byte) in mantissa_le_bytes.iter().copied().enumerate() {
+            if byte != 0 {
+                mantissa_first_nonzero_byte_index = i;
+                break;
+            }
+        }
+        let mantissa_le_bytes = &mantissa_le_bytes[mantissa_first_nonzero_byte_index..];
+        let shift = self.le_bytes.len() - mantissa_le_bytes.len();
+        let value_unsigned = if shift > (f64::MAX_EXP / 8).try_into().unwrap() {
+            f64::INFINITY
+        } else {
+            let mantissa = u64::from_le_bytes([
+                mantissa_le_bytes.first().copied().unwrap_or_default(),
+                mantissa_le_bytes.get(1).copied().unwrap_or_default(),
+                mantissa_le_bytes.get(2).copied().unwrap_or_default(),
+                mantissa_le_bytes.get(3).copied().unwrap_or_default(),
+                mantissa_le_bytes.get(4).copied().unwrap_or_default(),
+                mantissa_le_bytes.get(5).copied().unwrap_or_default(),
+                mantissa_le_bytes.get(6).copied().unwrap_or_default(),
+                mantissa_le_bytes.get(7).copied().unwrap_or_default(),
+            ]);
+            num_traits::ToPrimitive::to_f64(&mantissa).unwrap() * 2.0f64.powi(8 * shift as i32)
+        };
+        Some(if self.is_negative {
+            -value_unsigned
+        } else {
+            value_unsigned
+        })
+    }
+}
+
+impl num_traits::ToPrimitive for Bignum {
+    fn to_i64(&self) -> Option<i64> {
+        self.as_ref().to_i64()
+    }
+
+    fn to_i128(&self) -> Option<i128> {
+        self.as_ref().to_i128()
+    }
+
+    fn to_u64(&self) -> Option<u64> {
+        self.as_ref().to_u64()
+    }
+
+    fn to_u128(&self) -> Option<u128> {
+        self.as_ref().to_u128()
+    }
+
+    fn to_f64(&self) -> Option<f64> {
+        self.as_ref().to_f64()
+    }
+}
+
+impl num_bigint::ToBigInt for BignumRef<'_> {
+    fn to_bigint(&self) -> Option<num_bigint::BigInt> {
+        Some(self.into())
+    }
+}
+
+impl num_bigint::ToBigInt for Bignum {
+    fn to_bigint(&self) -> Option<num_bigint::BigInt> {
+        self.as_ref().to_bigint()
+    }
+}
+
+impl num_bigint::ToBigUint for BignumRef<'_> {
+    fn to_biguint(&self) -> Option<num_bigint::BigUint> {
+        (!self.is_negative).then(|| num_bigint::BigUint::from_bytes_le(self.le_bytes))
+    }
+}
+
+impl num_bigint::ToBigUint for Bignum {
+    fn to_biguint(&self) -> Option<num_bigint::BigUint> {
+        self.as_ref().to_biguint()
+    }
+}
+
+impl Ord for BignumRef<'_> {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        let ord = other.is_negative.cmp(&self.is_negative);
+        if ord.is_ne() {
+            return ord;
+        }
+        let ord = self.le_bytes.len().cmp(&other.le_bytes.len());
+        if ord.is_ne() {
+            return ord;
+        }
+        self.le_bytes.iter().rev().cmp(other.le_bytes.iter().rev())
+    }
+}
+
+impl Ord for Bignum {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.as_ref().cmp(&other.as_ref())
+    }
+}
+
+impl PartialOrd for BignumRef<'_> {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl PartialOrd for Bignum {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl std::fmt::Debug for BignumRef<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        num_bigint::BigInt::from(self).fmt(f)
+    }
+}
+
+impl std::fmt::Debug for Bignum {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.as_ref().fmt(f)
+    }
+}

--- a/alox-48/src/rb_types/bignum.rs
+++ b/alox-48/src/rb_types/bignum.rs
@@ -386,3 +386,15 @@ impl std::fmt::Debug for Bignum {
         self.as_ref().fmt(f)
     }
 }
+
+impl std::fmt::Display for BignumRef<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        num_bigint::BigInt::from(self).fmt(f)
+    }
+}
+
+impl std::fmt::Display for Bignum {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.as_ref().fmt(f)
+    }
+}

--- a/alox-48/src/rb_types/bignum.rs
+++ b/alox-48/src/rb_types/bignum.rs
@@ -216,8 +216,7 @@ impl num_traits::ToPrimitive for BignumRef<'_> {
     }
 
     fn to_f64(&self) -> Option<f64> {
-        let mantissa_le_bytes =
-            &self.le_bytes[self.le_bytes.len().saturating_sub(size_of::<u64>())..];
+        let mantissa_le_bytes = &self.le_bytes[self.le_bytes.len().saturating_sub(7)..];
         let shift = self.le_bytes.len() - mantissa_le_bytes.len();
         let value_unsigned = if shift > (f64::MAX_EXP / 8).try_into().unwrap() {
             f64::INFINITY

--- a/alox-48/src/rb_types/bignum.rs
+++ b/alox-48/src/rb_types/bignum.rs
@@ -4,7 +4,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use crate::{FromPrimitive, ToPrimitive};
+use crate::{FromPrimitive, NumCast, ToPrimitive};
 
 /// A type representing a borrowed arbitrary-precision integer outside of the interval
 /// [-2<sup>30</sup>, 2<sup>30</sup>).
@@ -233,6 +233,20 @@ impl ToPrimitive for Bignum {
 
     fn to_f64(&self) -> Option<f64> {
         self.as_ref().to_f64()
+    }
+}
+
+impl NumCast for Bignum {
+    fn from<T: ToPrimitive>(n: T) -> Option<Self> {
+        if let Some(n) = n.to_i128() {
+            FromPrimitive::from_i128(n)
+        } else if let Some(n) = n.to_u128() {
+            FromPrimitive::from_u128(n)
+        } else if let Some(n) = n.to_f64() {
+            FromPrimitive::from_f64(n)
+        } else {
+            None
+        }
     }
 }
 

--- a/alox-48/src/rb_types/bignum.rs
+++ b/alox-48/src/rb_types/bignum.rs
@@ -4,6 +4,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use crate::{FromPrimitive, ToPrimitive};
+
 /// A type representing a borrowed arbitrary-precision integer outside of the interval
 /// [-2<sup>30</sup>, 2<sup>30</sup>).
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -52,8 +54,9 @@ impl<'a> BignumRef<'a> {
             is_negative,
             le_bytes,
         };
-        num_traits::ToPrimitive::to_i32(&value)
-            .is_none_or(|int| <crate::Fixnum as num_traits::FromPrimitive>::from_i32(int).is_none())
+        value
+            .to_i32()
+            .is_none_or(|int| crate::Fixnum::from_i32(int).is_none())
             .then_some(value)
     }
 
@@ -73,8 +76,9 @@ impl Bignum {
             is_negative,
             le_bytes,
         };
-        num_traits::ToPrimitive::to_i32(&value)
-            .is_none_or(|int| <crate::Fixnum as num_traits::FromPrimitive>::from_i32(int).is_none())
+        value
+            .to_i32()
+            .is_none_or(|int| crate::Fixnum::from_i32(int).is_none())
             .then_some(value)
     }
 
@@ -120,7 +124,7 @@ impl From<&Bignum> for num_bigint::BigInt {
     }
 }
 
-impl num_traits::FromPrimitive for Bignum {
+impl FromPrimitive for Bignum {
     fn from_i64(n: i64) -> Option<Self> {
         Self::from_le_bytes(n.is_negative(), n.wrapping_abs().to_le_bytes().to_vec())
     }
@@ -154,7 +158,7 @@ impl num_traits::FromPrimitive for Bignum {
     }
 }
 
-impl num_traits::ToPrimitive for BignumRef<'_> {
+impl ToPrimitive for BignumRef<'_> {
     fn to_i64(&self) -> Option<i64> {
         (self.le_bytes.len() <= size_of::<i64>())
             .then(|| {
@@ -200,7 +204,7 @@ impl num_traits::ToPrimitive for BignumRef<'_> {
             f64::INFINITY
         } else {
             let mantissa = u64::from_le_bytes(super::to_array_with_default(mantissa_le_bytes));
-            num_traits::ToPrimitive::to_f64(&mantissa).unwrap() * 2.0f64.powi(8 * shift as i32)
+            mantissa.to_f64().unwrap() * 2.0f64.powi(8 * shift as i32)
         };
         Some(if self.is_negative {
             -value_unsigned
@@ -210,7 +214,7 @@ impl num_traits::ToPrimitive for BignumRef<'_> {
     }
 }
 
-impl num_traits::ToPrimitive for Bignum {
+impl ToPrimitive for Bignum {
     fn to_i64(&self) -> Option<i64> {
         self.as_ref().to_i64()
     }

--- a/alox-48/src/rb_types/bignum.rs
+++ b/alox-48/src/rb_types/bignum.rs
@@ -218,14 +218,6 @@ impl num_traits::ToPrimitive for BignumRef<'_> {
     fn to_f64(&self) -> Option<f64> {
         let mantissa_le_bytes =
             &self.le_bytes[self.le_bytes.len().saturating_sub(size_of::<u64>())..];
-        let mut mantissa_first_nonzero_byte_index = 0;
-        for (i, byte) in mantissa_le_bytes.iter().copied().enumerate() {
-            if byte != 0 {
-                mantissa_first_nonzero_byte_index = i;
-                break;
-            }
-        }
-        let mantissa_le_bytes = &mantissa_le_bytes[mantissa_first_nonzero_byte_index..];
         let shift = self.le_bytes.len() - mantissa_le_bytes.len();
         let value_unsigned = if shift > (f64::MAX_EXP / 8).try_into().unwrap() {
             f64::INFINITY

--- a/alox-48/src/rb_types/bignum.rs
+++ b/alox-48/src/rb_types/bignum.rs
@@ -5,7 +5,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 /// A type representing a borrowed arbitrary-precision integer outside of the interval
-/// $[-2^30, 2^30)$.
+/// [-2<sup>30</sup>, 2<sup>30</sup>).
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub struct BignumRef<'a> {
     /// True if the integer is less than zero, false if the integer is zero or greater than zero.
@@ -15,7 +15,7 @@ pub struct BignumRef<'a> {
 }
 
 /// A type representing an owned arbitrary-precision integer outside of the interval
-/// $[-2^30, 2^30)$.
+/// [-2<sup>30</sup>, 2<sup>30</sup>).
 #[derive(Clone, PartialEq, Eq)]
 pub struct Bignum {
     /// True if the integer is less than zero, false if the integer is zero or greater than zero.
@@ -43,8 +43,9 @@ impl<'a> From<BignumRef<'a>> for Bignum {
 }
 
 impl<'a> BignumRef<'a> {
-    /// Attempts to create a new `BignumRef` from a sign and little-endian bytes.
-    /// Will fail if the represented integer is within the interval $[-2^30, 2^30)$.
+    /// Attempts to create a new [`BignumRef`] from a sign and little-endian bytes.
+    /// Will fail if the represented integer is within the interval
+    /// [-2<sup>30</sup>, 2<sup>30</sup>).
     pub fn from_le_bytes(is_negative: bool, le_bytes: &'a [u8]) -> Option<Self> {
         let (is_negative, le_bytes) = super::canonicalize_le_bytes_ref(is_negative, le_bytes);
         let value = Self {
@@ -63,8 +64,9 @@ impl<'a> BignumRef<'a> {
 }
 
 impl Bignum {
-    /// Attempts to create a new `Bignum` from a sign and little-endian bytes.
-    /// Will fail if the represented integer is within the interval $[-2^30, 2^30)$.
+    /// Attempts to create a new [`Bignum`] from a sign and little-endian bytes.
+    /// Will fail if the represented integer is within the interval
+    /// [-2<sup>30</sup>, 2<sup>30</sup>).
     pub fn from_le_bytes(is_negative: bool, le_bytes: Vec<u8>) -> Option<Self> {
         let (is_negative, le_bytes) = super::canonicalize_le_bytes_vec(is_negative, le_bytes);
         let value = Self {
@@ -76,7 +78,7 @@ impl Bignum {
             .then_some(value)
     }
 
-    /// Borrows this object as a `BignumRef`.
+    /// Borrows this object as a [`BignumRef`].
     pub fn as_ref(&self) -> BignumRef<'_> {
         self.into()
     }

--- a/alox-48/src/rb_types/bignum.rs
+++ b/alox-48/src/rb_types/bignum.rs
@@ -44,6 +44,12 @@ impl<'a> From<BignumRef<'a>> for Bignum {
     }
 }
 
+impl<'a> From<&BignumRef<'a>> for Bignum {
+    fn from(value: &BignumRef<'a>) -> Self {
+        (*value).into()
+    }
+}
+
 impl<'a> BignumRef<'a> {
     /// Attempts to create a new [`BignumRef`] from a sign and little-endian bytes.
     /// Will fail if the represented integer is within the interval
@@ -58,6 +64,11 @@ impl<'a> BignumRef<'a> {
             .to_i32()
             .is_none_or(|int| crate::Fixnum::from_i32(int).is_none())
             .then_some(value)
+    }
+
+    /// Clones this object into a new [`Bignum`].
+    pub fn to_bignum(&self) -> Bignum {
+        self.into()
     }
 
     /// Returns the sign (true if negative, false if nonnegative) and little-endian bytes.

--- a/alox-48/src/rb_types/bignum.rs
+++ b/alox-48/src/rb_types/bignum.rs
@@ -46,12 +46,7 @@ impl<'a> BignumRef<'a> {
     /// Attempts to create a new `BignumRef` from a sign and little-endian bytes.
     /// Will fail if the represented integer is within the interval $[-2^30, 2^30)$.
     pub fn from_le_bytes(is_negative: bool, le_bytes: &'a [u8]) -> Option<Self> {
-        let le_bytes = &le_bytes[..super::get_le_bytes_size(le_bytes)];
-        let is_negative = if le_bytes.is_empty() {
-            false
-        } else {
-            is_negative
-        };
+        let (is_negative, le_bytes) = super::canonicalize_le_bytes_ref(is_negative, le_bytes);
         let value = Self {
             is_negative,
             le_bytes,
@@ -70,13 +65,8 @@ impl<'a> BignumRef<'a> {
 impl Bignum {
     /// Attempts to create a new `Bignum` from a sign and little-endian bytes.
     /// Will fail if the represented integer is within the interval $[-2^30, 2^30)$.
-    pub fn from_le_bytes(is_negative: bool, mut le_bytes: Vec<u8>) -> Option<Self> {
-        le_bytes.truncate(super::get_le_bytes_size(&le_bytes));
-        let is_negative = if le_bytes.is_empty() {
-            false
-        } else {
-            is_negative
-        };
+    pub fn from_le_bytes(is_negative: bool, le_bytes: Vec<u8>) -> Option<Self> {
+        let (is_negative, le_bytes) = super::canonicalize_le_bytes_vec(is_negative, le_bytes);
         let value = Self {
             is_negative,
             le_bytes,
@@ -130,34 +120,42 @@ impl From<&Bignum> for num_bigint::BigInt {
 
 impl num_traits::FromPrimitive for Bignum {
     fn from_i64(n: i64) -> Option<Self> {
-        let le_bytes = n.wrapping_abs().to_le_bytes();
-        crate::Fixnum::from_i64(n).is_none().then(|| Self {
-            is_negative: n.is_negative(),
-            le_bytes: le_bytes[..super::get_le_bytes_size(&le_bytes)].to_vec(),
+        let (is_negative, le_bytes) = super::canonicalize_le_bytes_vec(
+            n.is_negative(),
+            n.wrapping_abs().to_le_bytes().to_vec(),
+        );
+        crate::Fixnum::from_i64(n).is_none().then_some(Self {
+            is_negative,
+            le_bytes,
         })
     }
 
     fn from_i128(n: i128) -> Option<Self> {
-        let le_bytes = n.wrapping_abs().to_le_bytes();
-        crate::Fixnum::from_i128(n).is_none().then(|| Self {
-            is_negative: n.is_negative(),
-            le_bytes: le_bytes[..super::get_le_bytes_size(&le_bytes)].to_vec(),
+        let (is_negative, le_bytes) = super::canonicalize_le_bytes_vec(
+            n.is_negative(),
+            n.wrapping_abs().to_le_bytes().to_vec(),
+        );
+        crate::Fixnum::from_i128(n).is_none().then_some(Self {
+            is_negative,
+            le_bytes,
         })
     }
 
     fn from_u64(n: u64) -> Option<Self> {
-        let le_bytes = n.to_le_bytes();
-        crate::Fixnum::from_u64(n).is_none().then(|| Self {
-            is_negative: false,
-            le_bytes: le_bytes[..super::get_le_bytes_size(&le_bytes)].to_vec(),
+        let (is_negative, le_bytes) =
+            super::canonicalize_le_bytes_vec(false, n.to_le_bytes().to_vec());
+        crate::Fixnum::from_u64(n).is_none().then_some(Self {
+            is_negative,
+            le_bytes,
         })
     }
 
     fn from_u128(n: u128) -> Option<Self> {
-        let le_bytes = n.to_le_bytes();
-        crate::Fixnum::from_u128(n).is_none().then(|| Self {
-            is_negative: false,
-            le_bytes: le_bytes[..super::get_le_bytes_size(&le_bytes)].to_vec(),
+        let (is_negative, le_bytes) =
+            super::canonicalize_le_bytes_vec(false, n.to_le_bytes().to_vec());
+        crate::Fixnum::from_u128(n).is_none().then_some(Self {
+            is_negative,
+            le_bytes,
         })
     }
 

--- a/alox-48/src/rb_types/bignum.rs
+++ b/alox-48/src/rb_types/bignum.rs
@@ -354,15 +354,11 @@ impl num_bigint::ToBigUint for Bignum {
 
 impl Ord for BignumRef<'_> {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        let ord = other.is_negative.cmp(&self.is_negative);
-        if ord.is_ne() {
-            return ord;
-        }
-        let ord = self.le_bytes.len().cmp(&other.le_bytes.len());
-        if ord.is_ne() {
-            return ord;
-        }
-        self.le_bytes.iter().rev().cmp(other.le_bytes.iter().rev())
+        other
+            .is_negative
+            .cmp(&self.is_negative)
+            .then_with(|| self.le_bytes.len().cmp(&other.le_bytes.len()))
+            .then_with(|| self.le_bytes.iter().rev().cmp(other.le_bytes.iter().rev()))
     }
 }
 

--- a/alox-48/src/rb_types/bignum.rs
+++ b/alox-48/src/rb_types/bignum.rs
@@ -122,43 +122,19 @@ impl From<&Bignum> for num_bigint::BigInt {
 
 impl num_traits::FromPrimitive for Bignum {
     fn from_i64(n: i64) -> Option<Self> {
-        let (is_negative, le_bytes) = super::canonicalize_le_bytes_vec(
-            n.is_negative(),
-            n.wrapping_abs().to_le_bytes().to_vec(),
-        );
-        crate::Fixnum::from_i64(n).is_none().then_some(Self {
-            is_negative,
-            le_bytes,
-        })
+        Self::from_le_bytes(n.is_negative(), n.wrapping_abs().to_le_bytes().to_vec())
     }
 
     fn from_i128(n: i128) -> Option<Self> {
-        let (is_negative, le_bytes) = super::canonicalize_le_bytes_vec(
-            n.is_negative(),
-            n.wrapping_abs().to_le_bytes().to_vec(),
-        );
-        crate::Fixnum::from_i128(n).is_none().then_some(Self {
-            is_negative,
-            le_bytes,
-        })
+        Self::from_le_bytes(n.is_negative(), n.wrapping_abs().to_le_bytes().to_vec())
     }
 
     fn from_u64(n: u64) -> Option<Self> {
-        let (is_negative, le_bytes) =
-            super::canonicalize_le_bytes_vec(false, n.to_le_bytes().to_vec());
-        crate::Fixnum::from_u64(n).is_none().then_some(Self {
-            is_negative,
-            le_bytes,
-        })
+        Self::from_le_bytes(false, n.to_le_bytes().to_vec())
     }
 
     fn from_u128(n: u128) -> Option<Self> {
-        let (is_negative, le_bytes) =
-            super::canonicalize_le_bytes_vec(false, n.to_le_bytes().to_vec());
-        crate::Fixnum::from_u128(n).is_none().then_some(Self {
-            is_negative,
-            le_bytes,
-        })
+        Self::from_le_bytes(false, n.to_le_bytes().to_vec())
     }
 
     fn from_f64(n: f64) -> Option<Self> {

--- a/alox-48/src/rb_types/fixnum.rs
+++ b/alox-48/src/rb_types/fixnum.rs
@@ -128,3 +128,9 @@ impl std::fmt::Debug for Fixnum {
         self.0.fmt(f)
     }
 }
+
+impl std::fmt::Display for Fixnum {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}

--- a/alox-48/src/rb_types/fixnum.rs
+++ b/alox-48/src/rb_types/fixnum.rs
@@ -15,12 +15,7 @@ impl Fixnum {
         let (is_negative, le_bytes) = super::canonicalize_le_bytes_ref(is_negative, le_bytes);
         (le_bytes.len() <= size_of::<i32>())
             .then(|| {
-                let value = i32::from_le_bytes([
-                    le_bytes.first().copied().unwrap_or_default(),
-                    le_bytes.get(1).copied().unwrap_or_default(),
-                    le_bytes.get(2).copied().unwrap_or_default(),
-                    le_bytes.get(3).copied().unwrap_or_default(),
-                ]);
+                let value = i32::from_le_bytes(super::to_array_with_default(le_bytes));
                 let value = if is_negative {
                     value.wrapping_neg()
                 } else {

--- a/alox-48/src/rb_types/fixnum.rs
+++ b/alox-48/src/rb_types/fixnum.rs
@@ -4,7 +4,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use crate::{FromPrimitive, ToPrimitive};
+use crate::{FromPrimitive, NumCast, ToPrimitive};
 
 /// A type representing an integer within the interval [-2<sup>30</sup>, 2<sup>30</sup>).
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord)]
@@ -101,6 +101,12 @@ impl ToPrimitive for Fixnum {
 
     fn to_u64(&self) -> Option<u64> {
         self.0.to_u64()
+    }
+}
+
+impl NumCast for Fixnum {
+    fn from<T: ToPrimitive>(n: T) -> Option<Self> {
+        n.to_i32().and_then(FromPrimitive::from_i32)
     }
 }
 

--- a/alox-48/src/rb_types/fixnum.rs
+++ b/alox-48/src/rb_types/fixnum.rs
@@ -4,13 +4,14 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-/// A type representing an integer within the interval $[-2^30, 2^30)$.
+/// A type representing an integer within the interval [-2<sup>30</sup>, 2<sup>30</sup>).
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Fixnum(i32);
 
 impl Fixnum {
-    /// Attempts to create a new `Fixnum` from a sign and little-endian bytes.
-    /// Will fail if the represented integer is outside of the interval $[-2^30, 2^30)$.
+    /// Attempts to create a new [`Fixnum`] from a sign and little-endian bytes.
+    /// Will fail if the represented integer is outside of the interval
+    /// [-2<sup>30</sup>, 2<sup>30</sup>).
     pub fn from_le_bytes(is_negative: bool, le_bytes: &[u8]) -> Option<Self> {
         let (is_negative, le_bytes) = super::canonicalize_le_bytes_ref(is_negative, le_bytes);
         (le_bytes.len() <= size_of::<i32>())

--- a/alox-48/src/rb_types/fixnum.rs
+++ b/alox-48/src/rb_types/fixnum.rs
@@ -12,12 +12,7 @@ impl Fixnum {
     /// Attempts to create a new `Fixnum` from a sign and little-endian bytes.
     /// Will fail if the represented integer is outside of the interval $[-2^30, 2^30)$.
     pub fn from_le_bytes(is_negative: bool, le_bytes: &[u8]) -> Option<Self> {
-        let le_bytes = &le_bytes[..super::get_le_bytes_size(le_bytes)];
-        let is_negative = if le_bytes.is_empty() {
-            false
-        } else {
-            is_negative
-        };
+        let (is_negative, le_bytes) = super::canonicalize_le_bytes_ref(is_negative, le_bytes);
         (le_bytes.len() <= size_of::<i32>())
             .then(|| {
                 let value = i32::from_le_bytes([

--- a/alox-48/src/rb_types/fixnum.rs
+++ b/alox-48/src/rb_types/fixnum.rs
@@ -1,0 +1,130 @@
+// Copyright (c) 2024 Lily Lyons
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/// A type representing an integer within the interval $[-2^30, 2^30)$.
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Fixnum(i32);
+
+impl Fixnum {
+    /// Attempts to create a new `Fixnum` from a sign and little-endian bytes.
+    /// Will fail if the represented integer is outside of the interval $[-2^30, 2^30)$.
+    pub fn from_le_bytes(is_negative: bool, le_bytes: &[u8]) -> Option<Self> {
+        let le_bytes = &le_bytes[..super::get_le_bytes_size(le_bytes)];
+        let is_negative = if le_bytes.is_empty() {
+            false
+        } else {
+            is_negative
+        };
+        (le_bytes.len() <= size_of::<i32>())
+            .then(|| {
+                let value = i32::from_le_bytes([
+                    le_bytes.first().copied().unwrap_or_default(),
+                    le_bytes.get(1).copied().unwrap_or_default(),
+                    le_bytes.get(2).copied().unwrap_or_default(),
+                    le_bytes.get(3).copied().unwrap_or_default(),
+                ]);
+                let value = if is_negative {
+                    value.wrapping_neg()
+                } else {
+                    value
+                };
+                (value.is_negative() == is_negative)
+                    .then(|| num_traits::FromPrimitive::from_i32(value))
+                    .flatten()
+            })
+            .flatten()
+    }
+}
+
+impl From<i8> for Fixnum {
+    fn from(value: i8) -> Self {
+        Self(value.into())
+    }
+}
+
+impl From<u8> for Fixnum {
+    fn from(value: u8) -> Self {
+        Self(value.into())
+    }
+}
+
+impl From<i16> for Fixnum {
+    fn from(value: i16) -> Self {
+        Self(value.into())
+    }
+}
+
+impl From<u16> for Fixnum {
+    fn from(value: u16) -> Self {
+        Self(value.into())
+    }
+}
+
+impl From<Fixnum> for i32 {
+    fn from(value: Fixnum) -> Self {
+        value.0
+    }
+}
+
+impl From<Fixnum> for i64 {
+    fn from(value: Fixnum) -> Self {
+        value.0.into()
+    }
+}
+
+impl From<Fixnum> for i128 {
+    fn from(value: Fixnum) -> Self {
+        value.0.into()
+    }
+}
+
+impl From<Fixnum> for num_bigint::BigInt {
+    fn from(value: Fixnum) -> Self {
+        value.0.into()
+    }
+}
+
+impl num_traits::FromPrimitive for Fixnum {
+    fn from_i64(n: i64) -> Option<Self> {
+        if (-(1 << 30)..1 << 30).contains(&n) {
+            Some(Self(n as i32))
+        } else {
+            None
+        }
+    }
+
+    fn from_u64(n: u64) -> Option<Self> {
+        <u64 as num_traits::ToPrimitive>::to_i64(&n).and_then(Self::from_i64)
+    }
+}
+
+impl num_traits::ToPrimitive for Fixnum {
+    fn to_i64(&self) -> Option<i64> {
+        self.0.to_i64()
+    }
+
+    fn to_u64(&self) -> Option<u64> {
+        self.0.to_u64()
+    }
+}
+
+impl num_bigint::ToBigInt for Fixnum {
+    fn to_bigint(&self) -> Option<num_bigint::BigInt> {
+        self.0.to_bigint()
+    }
+}
+
+impl num_bigint::ToBigUint for Fixnum {
+    fn to_biguint(&self) -> Option<num_bigint::BigUint> {
+        self.0.to_biguint()
+    }
+}
+
+impl std::fmt::Debug for Fixnum {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}

--- a/alox-48/src/rb_types/fixnum.rs
+++ b/alox-48/src/rb_types/fixnum.rs
@@ -4,6 +4,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use crate::{FromPrimitive, ToPrimitive};
+
 /// A type representing an integer within the interval [-2<sup>30</sup>, 2<sup>30</sup>).
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Fixnum(i32);
@@ -23,7 +25,7 @@ impl Fixnum {
                     value
                 };
                 (value.is_negative() == is_negative)
-                    .then(|| num_traits::FromPrimitive::from_i32(value))
+                    .then(|| FromPrimitive::from_i32(value))
                     .flatten()
             })
             .flatten()
@@ -78,7 +80,7 @@ impl From<Fixnum> for num_bigint::BigInt {
     }
 }
 
-impl num_traits::FromPrimitive for Fixnum {
+impl FromPrimitive for Fixnum {
     fn from_i64(n: i64) -> Option<Self> {
         if (-(1 << 30)..1 << 30).contains(&n) {
             Some(Self(n as i32))
@@ -88,11 +90,11 @@ impl num_traits::FromPrimitive for Fixnum {
     }
 
     fn from_u64(n: u64) -> Option<Self> {
-        <u64 as num_traits::ToPrimitive>::to_i64(&n).and_then(Self::from_i64)
+        n.to_i64().and_then(Self::from_i64)
     }
 }
 
-impl num_traits::ToPrimitive for Fixnum {
+impl ToPrimitive for Fixnum {
     fn to_i64(&self) -> Option<i64> {
         self.0.to_i64()
     }

--- a/alox-48/src/rb_types/fixnum.rs
+++ b/alox-48/src/rb_types/fixnum.rs
@@ -110,6 +110,37 @@ impl NumCast for Fixnum {
     }
 }
 
+macro_rules! try_from_impl {
+    ($($from:ty => $to:ty),* $(,)?) => {
+        $(impl TryFrom<$from> for $to {
+            type Error = $from;
+            fn try_from(value: $from) -> Result<Self, Self::Error> {
+                NumCast::from(value).ok_or(value)
+            }
+        })*
+    };
+}
+
+try_from_impl! {
+    i32 => Fixnum,
+    u32 => Fixnum,
+    i64 => Fixnum,
+    u64 => Fixnum,
+    i128 => Fixnum,
+    u128 => Fixnum,
+    isize => Fixnum,
+    usize => Fixnum,
+    Fixnum => i8,
+    Fixnum => u8,
+    Fixnum => i16,
+    Fixnum => u16,
+    Fixnum => u32,
+    Fixnum => u64,
+    Fixnum => u128,
+    Fixnum => isize,
+    Fixnum => usize,
+}
+
 impl num_bigint::ToBigInt for Fixnum {
     fn to_bigint(&self) -> Option<num_bigint::BigInt> {
         self.0.to_bigint()

--- a/alox-48/src/rb_types/mod.rs
+++ b/alox-48/src/rb_types/mod.rs
@@ -59,3 +59,12 @@ fn canonicalize_le_bytes_vec(is_negative: bool, mut le_bytes: Vec<u8>) -> (bool,
     le_bytes.truncate(le_bytes_size);
     (is_negative, le_bytes)
 }
+
+/// If `slice` contains at least `N` elements, returns a copy of the first `N` elements. Otherwise,
+/// returns a copy of `slice` zero-extended at the end.
+fn to_array_with_default<const N: usize>(slice: &[u8]) -> [u8; N] {
+    let mut bytes = [0u8; N];
+    let copy_size = N.min(slice.len());
+    bytes[..copy_size].copy_from_slice(&slice[..copy_size]);
+    bytes
+}

--- a/alox-48/src/rb_types/mod.rs
+++ b/alox-48/src/rb_types/mod.rs
@@ -6,6 +6,8 @@
 use super::Value;
 use indexmap::IndexMap;
 
+mod bignum;
+mod fixnum;
 mod instance;
 mod object;
 mod rb_string;
@@ -14,6 +16,8 @@ mod sym;
 mod symbol;
 mod userdata;
 
+pub use bignum::{Bignum, BignumRef};
+pub use fixnum::Fixnum;
 pub use instance::Instance;
 pub use object::Object;
 pub use rb_string::RbString;
@@ -30,3 +34,13 @@ pub type RbHash = IndexMap<Value, Value>;
 /// A type alias used to represent fields of objects.
 /// All objects store a [`Symbol`] to represent the key for instance variable, and we do that here too.
 pub type RbFields = IndexMap<Symbol, Value>;
+
+/// Returns the size of `le_bytes` excluding trailing null bytes.
+fn get_le_bytes_size(le_bytes: &[u8]) -> usize {
+    for (i, byte) in le_bytes.iter().copied().enumerate().rev() {
+        if byte != 0 {
+            return i + 1;
+        }
+    }
+    0
+}

--- a/alox-48/src/rb_types/mod.rs
+++ b/alox-48/src/rb_types/mod.rs
@@ -35,12 +35,28 @@ pub type RbHash = IndexMap<Value, Value>;
 /// All objects store a [`Symbol`] to represent the key for instance variable, and we do that here too.
 pub type RbFields = IndexMap<Symbol, Value>;
 
-/// Returns the size of `le_bytes` excluding trailing null bytes.
-fn get_le_bytes_size(le_bytes: &[u8]) -> usize {
+/// Returns `false` if `le_bytes` contains only zero bytes or `is_negative` otherwise, and the size
+/// of `le_bytes` excluding trailing zero bytes.
+fn get_canonical_le_bytes_info(is_negative: bool, le_bytes: &[u8]) -> (bool, usize) {
     for (i, byte) in le_bytes.iter().copied().enumerate().rev() {
         if byte != 0 {
-            return i + 1;
+            return (is_negative, i + 1);
         }
     }
-    0
+    (false, 0)
+}
+
+/// Returns an unambiguous version of the integer represented by the given sign and little-endian
+/// bytes.
+fn canonicalize_le_bytes_ref(is_negative: bool, le_bytes: &[u8]) -> (bool, &[u8]) {
+    let (is_negative, le_bytes_size) = get_canonical_le_bytes_info(is_negative, le_bytes);
+    (is_negative, &le_bytes[..le_bytes_size])
+}
+
+/// Returns an unambiguous version of the integer represented by the given sign and little-endian
+/// bytes.
+fn canonicalize_le_bytes_vec(is_negative: bool, mut le_bytes: Vec<u8>) -> (bool, Vec<u8>) {
+    let (is_negative, le_bytes_size) = get_canonical_le_bytes_info(is_negative, &le_bytes);
+    le_bytes.truncate(le_bytes_size);
+    (is_negative, le_bytes)
 }

--- a/alox-48/src/rb_types/mod.rs
+++ b/alox-48/src/rb_types/mod.rs
@@ -38,12 +38,11 @@ pub type RbFields = IndexMap<Symbol, Value>;
 /// Returns `false` if `le_bytes` contains only zero bytes or `is_negative` otherwise, and the size
 /// of `le_bytes` excluding trailing zero bytes.
 fn get_canonical_le_bytes_info(is_negative: bool, le_bytes: &[u8]) -> (bool, usize) {
-    for (i, byte) in le_bytes.iter().copied().enumerate().rev() {
-        if byte != 0 {
-            return (is_negative, i + 1);
-        }
+    if let Some((i, _)) = le_bytes.iter().enumerate().rfind(|(_, byte)| **byte != 0) {
+        (is_negative, i + 1)
+    } else {
+        (false, 0)
     }
-    (false, 0)
 }
 
 /// Returns an unambiguous version of the integer represented by the given sign and little-endian

--- a/alox-48/src/ser/error.rs
+++ b/alox-48/src/ser/error.rs
@@ -22,6 +22,8 @@ pub enum Kind {
     OvershotProvidedLen(usize, usize),
     #[error("Undershot the provided len {0} < {1}")]
     UndershotProvidedLen(usize, usize),
+    #[error("Object of length {0} is too large to be serialized (maximum allowed is 2^30 - 1)")]
+    LenOverflow(usize),
     #[error("Custom error: {0}")]
     Message(String),
     #[error("Tried to serialize a key without a value")]

--- a/alox-48/src/ser/impls.rs
+++ b/alox-48/src/ser/impls.rs
@@ -4,7 +4,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 use super::{Error, Kind, Result, Serialize, SerializeArray, SerializerTrait};
-use crate::Bignum;
+use crate::{Bignum, FromPrimitive};
 use std::{
     cell::{Cell, RefCell},
     collections::{BTreeMap, BTreeSet, BinaryHeap, HashMap, HashSet, LinkedList, VecDeque},
@@ -29,10 +29,10 @@ macro_rules! primitive_int_impl {
             where
                 S: SerializerTrait
             {
-                if let Some(fixnum) = num_traits::FromPrimitive::$from_primitive(*self) {
+                if let Some(fixnum) = FromPrimitive::$from_primitive(*self) {
                     serializer.serialize_fixnum(fixnum)
                 } else {
-                    let bignum: Bignum = num_traits::FromPrimitive::$from_primitive(*self).unwrap();
+                    let bignum: Bignum = FromPrimitive::$from_primitive(*self).unwrap();
                     serializer.serialize_bignum(bignum.as_ref())
                 }
             }

--- a/alox-48/src/ser/impls.rs
+++ b/alox-48/src/ser/impls.rs
@@ -29,15 +29,27 @@ macro_rules! primitive_int_impl {
             where
                 S: SerializerTrait
             {
-                serializer.serialize_i32(*self as i32)
+                serializer.serialize_bignum(self.clone().into())
             }
         })*
     };
 }
 
 primitive_int_impl! {
-    u8, u16, u32, u64, u128, usize,
-    i8, i16, i32, i64, i128, isize
+    u8,
+    u16,
+    u32,
+    u64,
+    u128,
+    usize,
+    num_bigint::BigUint,
+    i8,
+    i16,
+    i32,
+    i64,
+    i128,
+    isize,
+    num_bigint::BigInt
 }
 
 impl Serialize for f32 {

--- a/alox-48/src/ser/impls.rs
+++ b/alox-48/src/ser/impls.rs
@@ -3,6 +3,8 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
+use super::{Error, Kind, Result, Serialize, SerializeArray, SerializerTrait};
+use crate::Bignum;
 use std::{
     cell::{Cell, RefCell},
     collections::{BTreeMap, BTreeSet, BinaryHeap, HashMap, HashSet, LinkedList, VecDeque},
@@ -18,38 +20,39 @@ use std::{
     },
 };
 
-use super::{Error, Kind, Result, Serialize, SerializeArray, SerializerTrait};
-
 // some of these macros are lifted directly from serde.
 // serde is under a fairly permissive license (and any macro i would write would likely look identical) so this is okay.
 macro_rules! primitive_int_impl {
-    ($($primitive:ty),*) => {
+    ($($primitive:ty => $from_primitive:ident),* $(,)?) => {
         $(impl Serialize for $primitive {
             fn serialize<S>(&self, serializer: S) -> Result<S::Ok>
             where
                 S: SerializerTrait
             {
-                serializer.serialize_bignum(self.clone().into())
+                if let Some(fixnum) = num_traits::FromPrimitive::$from_primitive(*self) {
+                    serializer.serialize_fixnum(fixnum)
+                } else {
+                    let bignum: Bignum = num_traits::FromPrimitive::$from_primitive(*self).unwrap();
+                    serializer.serialize_bignum(bignum.as_ref())
+                }
             }
         })*
     };
 }
 
 primitive_int_impl! {
-    u8,
-    u16,
-    u32,
-    u64,
-    u128,
-    usize,
-    num_bigint::BigUint,
-    i8,
-    i16,
-    i32,
-    i64,
-    i128,
-    isize,
-    num_bigint::BigInt
+    u8 => from_u8,
+    u16 => from_u16,
+    u32 => from_u32,
+    u64 => from_u64,
+    u128 => from_u128,
+    usize => from_usize,
+    i8 => from_i8,
+    i16 => from_i16,
+    i32 => from_i32,
+    i64 => from_i64,
+    i128 => from_i128,
+    isize => from_isize,
 }
 
 impl Serialize for f32 {

--- a/alox-48/src/ser/impls.rs
+++ b/alox-48/src/ser/impls.rs
@@ -4,7 +4,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 use super::{Error, Kind, Result, Serialize, SerializeArray, SerializerTrait};
-use crate::{Bignum, FromPrimitive};
+use crate::{Bignum, NumCast};
 use std::{
     cell::{Cell, RefCell},
     collections::{BTreeMap, BTreeSet, BinaryHeap, HashMap, HashSet, LinkedList, VecDeque},
@@ -23,17 +23,16 @@ use std::{
 // some of these macros are lifted directly from serde.
 // serde is under a fairly permissive license (and any macro i would write would likely look identical) so this is okay.
 macro_rules! primitive_int_impl {
-    ($($primitive:ty => $from_primitive:ident),* $(,)?) => {
+    ($($primitive:ty),* $(,)?) => {
         $(impl Serialize for $primitive {
             fn serialize<S>(&self, serializer: S) -> Result<S::Ok>
             where
                 S: SerializerTrait
             {
-                if let Some(fixnum) = FromPrimitive::$from_primitive(*self) {
+                if let Some(fixnum) = NumCast::from(*self) {
                     serializer.serialize_fixnum(fixnum)
                 } else {
-                    let bignum: Bignum = FromPrimitive::$from_primitive(*self).unwrap();
-                    serializer.serialize_bignum(bignum.as_ref())
+                    serializer.serialize_bignum(<Bignum as NumCast>::from(*self).unwrap().as_ref())
                 }
             }
         })*
@@ -41,18 +40,18 @@ macro_rules! primitive_int_impl {
 }
 
 primitive_int_impl! {
-    u8 => from_u8,
-    u16 => from_u16,
-    u32 => from_u32,
-    u64 => from_u64,
-    u128 => from_u128,
-    usize => from_usize,
-    i8 => from_i8,
-    i16 => from_i16,
-    i32 => from_i32,
-    i64 => from_i64,
-    i128 => from_i128,
-    isize => from_isize,
+    u8,
+    u16,
+    u32,
+    u64,
+    u128,
+    usize,
+    i8,
+    i16,
+    i32,
+    i64,
+    i128,
+    isize,
 }
 
 impl Serialize for f32 {
@@ -60,7 +59,7 @@ impl Serialize for f32 {
     where
         S: SerializerTrait,
     {
-        serializer.serialize_f64(f64::from(*self))
+        serializer.serialize_f64((*self).into())
     }
 }
 

--- a/alox-48/src/ser/serializer.rs
+++ b/alox-48/src/ser/serializer.rs
@@ -8,7 +8,7 @@
 use indexmap::IndexSet;
 
 use super::{Error, Kind, Result};
-use crate::{tag::Tag, BignumRef, Fixnum, Sym, Symbol};
+use crate::{tag::Tag, BignumRef, Fixnum, FromPrimitive, Sym, Symbol};
 
 /// The `alox_48` serializer.
 #[derive(Debug, Clone)]
@@ -99,7 +99,7 @@ impl Serializer {
     }
 
     fn write_usize(&mut self, v: usize) -> Result<()> {
-        self.write_fixnum(num_traits::FromPrimitive::from_usize(v).ok_or(Error {
+        self.write_fixnum(FromPrimitive::from_usize(v).ok_or(Error {
             kind: Kind::LenOverflow(v),
         })?);
         Ok(())

--- a/alox-48/src/ser/serializer.rs
+++ b/alox-48/src/ser/serializer.rs
@@ -154,9 +154,24 @@ impl<'a> super::SerializerTrait for &'a mut Serializer {
         Ok(())
     }
 
-    fn serialize_i32(self, v: i32) -> Result<Self::Ok> {
-        self.write(Tag::Integer);
-        self.write_int(v as i64);
+    fn serialize_bignum(self, v: num_bigint::BigInt) -> Result<Self::Ok> {
+        if let Ok(v) = <_ as TryInto<i32>>::try_into(v.clone()) {
+            self.write(Tag::Fixnum);
+            self.write_int(v as i64);
+        } else {
+            self.write(Tag::Bignum);
+            let (sign, bytes) = v.to_bytes_le();
+            self.write(if sign == num_bigint::Sign::Minus {
+                b'-'
+            } else {
+                b'+'
+            });
+            self.write_int(bytes.len().div_ceil(2) as i64);
+            self.write_bytes(&bytes);
+            if bytes.len() % 2 != 0 {
+                self.write(0u8);
+            }
+        }
 
         Ok(())
     }

--- a/alox-48/src/ser/serializer.rs
+++ b/alox-48/src/ser/serializer.rs
@@ -8,7 +8,7 @@
 use indexmap::IndexSet;
 
 use super::{Error, Kind, Result};
-use crate::{tag::Tag, Sym, Symbol};
+use crate::{tag::Tag, BignumRef, Fixnum, Sym, Symbol};
 
 /// The `alox_48` serializer.
 #[derive(Debug, Clone)]
@@ -154,27 +154,24 @@ impl<'a> super::SerializerTrait for &'a mut Serializer {
         Ok(())
     }
 
-    fn serialize_bignum(self, v: num_bigint::BigInt) -> Result<Self::Ok> {
-        use num_traits::FromPrimitive;
-        if (num_bigint::BigInt::from_i32(-(1 << 30)).unwrap()
-            ..num_bigint::BigInt::from_i32(1 << 30).unwrap())
-            .contains(&v)
-        {
-            self.write(Tag::Fixnum);
-            self.write_int(v.try_into().unwrap());
-        } else {
-            self.write(Tag::Bignum);
-            let (sign, bytes) = v.to_bytes_le();
-            self.write(if sign == num_bigint::Sign::Minus {
-                b'-'
-            } else {
-                b'+'
-            });
-            self.write_int(bytes.len().div_ceil(2) as i64);
-            self.write_bytes(&bytes);
-            if bytes.len() % 2 != 0 {
-                self.write(0u8);
-            }
+    fn serialize_fixnum(self, v: Fixnum) -> Result<Self::Ok> {
+        self.write(Tag::Fixnum);
+        self.write_int(v.into());
+
+        Ok(())
+    }
+
+    fn serialize_bignum(self, v: BignumRef<'_>) -> Result<Self::Ok> {
+        self.write(Tag::Bignum);
+
+        let (is_negative, le_bytes) = v.as_le_bytes();
+
+        self.write(if is_negative { b'-' } else { b'+' });
+
+        self.write_int(le_bytes.len().div_ceil(2) as i64);
+        self.write_bytes(le_bytes);
+        if le_bytes.len() % 2 != 0 {
+            self.write(0u8);
         }
 
         Ok(())

--- a/alox-48/src/ser/serializer.rs
+++ b/alox-48/src/ser/serializer.rs
@@ -155,9 +155,13 @@ impl<'a> super::SerializerTrait for &'a mut Serializer {
     }
 
     fn serialize_bignum(self, v: num_bigint::BigInt) -> Result<Self::Ok> {
-        if let Ok(v) = <_ as TryInto<i32>>::try_into(v.clone()) {
+        use num_traits::FromPrimitive;
+        if (num_bigint::BigInt::from_i32(-(1 << 30)).unwrap()
+            ..num_bigint::BigInt::from_i32(1 << 30).unwrap())
+            .contains(&v)
+        {
             self.write(Tag::Fixnum);
-            self.write_int(v as i64);
+            self.write_int(v.try_into().unwrap());
         } else {
             self.write(Tag::Bignum);
             let (sign, bytes) = v.to_bytes_le();

--- a/alox-48/src/ser/serializer.rs
+++ b/alox-48/src/ser/serializer.rs
@@ -66,13 +66,8 @@ impl Serializer {
     }
 
     // Does not emit a type byte.
-    // FIXME: find a way around these warnings
-    #[allow(
-        clippy::cast_precision_loss,
-        clippy::cast_sign_loss,
-        clippy::cast_possible_truncation
-    )]
-    fn write_int(&mut self, v: i64) {
+    fn write_fixnum(&mut self, v: Fixnum) {
+        let v: i32 = v.into();
         match v {
             0 => self.write(0),
             1..=122 => self.write(v as u8 + 5),
@@ -103,22 +98,31 @@ impl Serializer {
         }
     }
 
+    fn write_usize(&mut self, v: usize) -> Result<()> {
+        self.write_fixnum(num_traits::FromPrimitive::from_usize(v).ok_or(Error {
+            kind: Kind::LenOverflow(v),
+        })?);
+        Ok(())
+    }
+
     fn write(&mut self, b: impl Into<u8>) {
         self.output.push(b.into());
     }
 
-    fn write_symbol(&mut self, symbol: &Sym) {
+    fn write_symbol(&mut self, symbol: &Sym) -> Result<()> {
         if let Some(idx) = self.symlink.get_index_of(symbol) {
             self.write(Tag::Symlink);
-            self.write_int(idx as _);
+            self.write_usize(idx)?;
         } else {
             self.symlink.insert(symbol.to_symbol());
 
             self.write(Tag::Symbol);
-            self.write_int(symbol.len() as _);
+            self.write_usize(symbol.len())?;
 
             self.write_bytes(symbol);
         }
+
+        Ok(())
     }
 
     fn write_bytes(&mut self, bytes: impl AsRef<[u8]>) {
@@ -127,11 +131,13 @@ impl Serializer {
         }
     }
 
-    fn write_bytes_len(&mut self, bytes: impl AsRef<[u8]>) {
+    fn write_bytes_len(&mut self, bytes: impl AsRef<[u8]>) -> Result<()> {
         let bytes = bytes.as_ref();
 
-        self.write_int(bytes.len() as _);
+        self.write_usize(bytes.len())?;
         self.write_bytes(bytes);
+
+        Ok(())
     }
 }
 
@@ -156,7 +162,7 @@ impl<'a> super::SerializerTrait for &'a mut Serializer {
 
     fn serialize_fixnum(self, v: Fixnum) -> Result<Self::Ok> {
         self.write(Tag::Fixnum);
-        self.write_int(v.into());
+        self.write_fixnum(v);
 
         Ok(())
     }
@@ -168,7 +174,7 @@ impl<'a> super::SerializerTrait for &'a mut Serializer {
 
         self.write(if is_negative { b'-' } else { b'+' });
 
-        self.write_int(le_bytes.len().div_ceil(2) as i64);
+        self.write_usize(le_bytes.len().div_ceil(2))?;
         self.write_bytes(le_bytes);
         if le_bytes.len() % 2 != 0 {
             self.write(0u8);
@@ -181,14 +187,14 @@ impl<'a> super::SerializerTrait for &'a mut Serializer {
         self.write(Tag::Float);
 
         let str = v.to_string();
-        self.write_bytes_len(str);
+        self.write_bytes_len(str)?;
 
         Ok(())
     }
 
     fn serialize_hash(self, len: usize) -> Result<Self::SerializeHash> {
         self.write(Tag::Hash);
-        self.write_int(len as _);
+        self.write_usize(len)?;
 
         Ok(SerializeHash {
             serializer: self,
@@ -200,7 +206,7 @@ impl<'a> super::SerializerTrait for &'a mut Serializer {
 
     fn serialize_array(self, len: usize) -> Result<Self::SerializeArray> {
         self.write(Tag::Array);
-        self.write_int(len as _);
+        self.write_usize(len)?;
 
         Ok(SerializeArray {
             serializer: self,
@@ -211,20 +217,20 @@ impl<'a> super::SerializerTrait for &'a mut Serializer {
 
     fn serialize_string(self, data: &[u8]) -> Result<Self::Ok> {
         self.write(Tag::String);
-        self.write_bytes_len(data);
+        self.write_bytes_len(data)?;
 
         Ok(())
     }
 
     fn serialize_symbol(self, sym: &Sym) -> Result<Self::Ok> {
-        self.write_symbol(sym);
+        self.write_symbol(sym)?;
 
         Ok(())
     }
 
     fn serialize_regular_expression(self, regex: &[u8], flags: u8) -> Result<Self::Ok> {
         self.write(Tag::RawRegexp);
-        self.write_bytes_len(regex);
+        self.write_bytes_len(regex)?;
         self.write(flags);
 
         Ok(())
@@ -232,8 +238,8 @@ impl<'a> super::SerializerTrait for &'a mut Serializer {
 
     fn serialize_object(self, class: &Sym, len: usize) -> Result<Self::SerializeIvars> {
         self.write(Tag::Object);
-        self.write_symbol(class);
-        self.write_int(len as _);
+        self.write_symbol(class)?;
+        self.write_usize(len)?;
 
         Ok(SerializeIvars {
             serializer: self,
@@ -245,8 +251,8 @@ impl<'a> super::SerializerTrait for &'a mut Serializer {
 
     fn serialize_struct(self, name: &Sym, len: usize) -> Result<Self::SerializeIvars> {
         self.write(Tag::Struct);
-        self.write_symbol(name);
-        self.write_int(len as _);
+        self.write_symbol(name)?;
+        self.write_usize(len)?;
 
         Ok(SerializeIvars {
             serializer: self,
@@ -259,14 +265,14 @@ impl<'a> super::SerializerTrait for &'a mut Serializer {
     fn serialize_class(self, class: &Sym) -> Result<Self::Ok> {
         self.write(Tag::ClassRef);
         // Apparently, this isn't a symbol. How strange!
-        self.write_bytes_len(class);
+        self.write_bytes_len(class)?;
 
         Ok(())
     }
 
     fn serialize_module(self, module: &Sym) -> Result<Self::Ok> {
         self.write(Tag::ModuleRef);
-        self.write_bytes_len(module);
+        self.write_bytes_len(module)?;
 
         Ok(())
     }
@@ -277,7 +283,7 @@ impl<'a> super::SerializerTrait for &'a mut Serializer {
     {
         self.write(Tag::Instance);
         value.serialize(&mut *self)?;
-        self.write_int(len as _);
+        self.write_usize(len)?;
 
         Ok(SerializeIvars {
             serializer: self,
@@ -293,7 +299,7 @@ impl<'a> super::SerializerTrait for &'a mut Serializer {
     {
         // the ruby docs lie! it is the module which comes before the value.
         self.write(Tag::Extended);
-        self.write_symbol(module);
+        self.write_symbol(module)?;
         value.serialize(self)
     }
 
@@ -302,14 +308,14 @@ impl<'a> super::SerializerTrait for &'a mut Serializer {
         V: crate::Serialize + ?Sized,
     {
         self.write(Tag::UserClass);
-        self.write_symbol(class);
+        self.write_symbol(class)?;
         value.serialize(self)
     }
 
     fn serialize_user_data(self, class: &Sym, data: &[u8]) -> Result<Self::Ok> {
         self.write(Tag::UserDef);
-        self.write_symbol(class);
-        self.write_bytes_len(data);
+        self.write_symbol(class)?;
+        self.write_bytes_len(data)?;
 
         Ok(())
     }
@@ -319,7 +325,7 @@ impl<'a> super::SerializerTrait for &'a mut Serializer {
         V: crate::Serialize + ?Sized,
     {
         self.write(Tag::UserMarshal);
-        self.write_symbol(class);
+        self.write_symbol(class)?;
         value.serialize(self)
     }
 
@@ -328,7 +334,7 @@ impl<'a> super::SerializerTrait for &'a mut Serializer {
         V: crate::Serialize + ?Sized,
     {
         self.write(Tag::Data);
-        self.write_symbol(class);
+        self.write_symbol(class)?;
         value.serialize(self)
     }
 }
@@ -352,7 +358,7 @@ impl super::SerializeIvars for SerializeIvars<'_> {
             MapState::Value => self.state = MapState::Key,
         }
 
-        self.serializer.write_symbol(k);
+        self.serializer.write_symbol(k)?;
 
         Ok(())
     }

--- a/alox-48/src/ser/traits.rs
+++ b/alox-48/src/ser/traits.rs
@@ -36,7 +36,7 @@ pub trait Serializer: Sized {
     fn serialize_bool(self, v: bool) -> Result<Self::Ok>;
 
     /// Serialize an integer value.
-    fn serialize_i32(self, v: i32) -> Result<Self::Ok>;
+    fn serialize_bignum(self, v: num_bigint::BigInt) -> Result<Self::Ok>;
 
     /// Serialize a float value.
     fn serialize_f64(self, v: f64) -> Result<Self::Ok>;

--- a/alox-48/src/ser/traits.rs
+++ b/alox-48/src/ser/traits.rs
@@ -35,10 +35,10 @@ pub trait Serializer: Sized {
     /// Serialize a boolean value.
     fn serialize_bool(self, v: bool) -> Result<Self::Ok>;
 
-    /// Serialize an integer value within the interval $[-2^30, 2^30)$.
+    /// Serialize an integer value within the interval [-2<sup>30</sup>, 2<sup>30</sup>).
     fn serialize_fixnum(self, v: Fixnum) -> Result<Self::Ok>;
 
-    /// Serialize an integer value outside of the interval $[-2^30, 2^30)$.
+    /// Serialize an integer value outside of the interval [-2<sup>30</sup>, 2<sup>30</sup>).
     fn serialize_bignum(self, v: BignumRef<'_>) -> Result<Self::Ok>;
 
     /// Serialize a float value.

--- a/alox-48/src/ser/traits.rs
+++ b/alox-48/src/ser/traits.rs
@@ -1,11 +1,11 @@
-use crate::Sym;
-
 // Copyright (c) 2024 Lily Lyons
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 use super::Result;
+use crate::{BignumRef, Fixnum, Sym};
 
 /// A structure that can be serialized into ruby marshal data.
 pub trait Serialize {
@@ -35,8 +35,11 @@ pub trait Serializer: Sized {
     /// Serialize a boolean value.
     fn serialize_bool(self, v: bool) -> Result<Self::Ok>;
 
-    /// Serialize an integer value.
-    fn serialize_bignum(self, v: num_bigint::BigInt) -> Result<Self::Ok>;
+    /// Serialize an integer value within the interval $[-2^30, 2^30)$.
+    fn serialize_fixnum(self, v: Fixnum) -> Result<Self::Ok>;
+
+    /// Serialize an integer value outside of the interval $[-2^30, 2^30)$.
+    fn serialize_bignum(self, v: BignumRef<'_>) -> Result<Self::Ok>;
 
     /// Serialize a float value.
     fn serialize_f64(self, v: f64) -> Result<Self::Ok>;

--- a/alox-48/src/tag.rs
+++ b/alox-48/src/tag.rs
@@ -14,9 +14,11 @@ pub enum Tag {
 
     False = b'F',
 
-    Integer = b'i',
+    Fixnum = b'i',
 
     Float = b'f',
+
+    Bignum = b'l',
 
     String = b'\"',
 
@@ -61,8 +63,9 @@ impl Tag {
             b'0' => Some(Tag::Nil),
             b'T' => Some(Tag::True),
             b'F' => Some(Tag::False),
-            b'i' => Some(Tag::Integer),
+            b'i' => Some(Tag::Fixnum),
             b'f' => Some(Tag::Float),
+            b'l' => Some(Tag::Bignum),
             b'\"' => Some(Tag::String),
             b'[' => Some(Tag::Array),
             b'{' => Some(Tag::Hash),
@@ -91,7 +94,9 @@ impl Tag {
             Self::Nil
                 | Self::True
                 | Self::False
-                | Self::Integer
+                | Self::Fixnum
+                | Self::Float
+                | Self::Bignum
                 | Self::Symbol
                 | Self::Symlink
                 | Self::ObjectLink

--- a/alox-48/src/value/de.rs
+++ b/alox-48/src/value/de.rs
@@ -5,9 +5,9 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 use crate::{
     de::{DeserializeSeed, Error, Kind, Result},
-    ArrayAccess, Deserialize, DeserializerTrait, HashAccess, Instance, InstanceAccess, IvarAccess,
-    Object, RbFields, RbHash, RbString, Sym, Userdata, Value, Visitor, VisitorInstance,
-    VisitorOption,
+    ArrayAccess, BignumRef, Deserialize, DeserializerTrait, Fixnum, HashAccess, Instance,
+    InstanceAccess, IvarAccess, Object, RbFields, RbHash, RbString, Sym, Userdata, Value, Visitor,
+    VisitorInstance, VisitorOption,
 };
 
 struct ValueVisitor;
@@ -27,8 +27,12 @@ impl<'de> Visitor<'de> for ValueVisitor {
         Ok(Value::Bool(v))
     }
 
-    fn visit_bignum(self, v: num_bigint::BigInt) -> Result<Self::Value> {
-        Ok(Value::Integer(v))
+    fn visit_fixnum(self, v: Fixnum) -> Result<Self::Value> {
+        Ok(Value::Fixnum(v))
+    }
+
+    fn visit_bignum(self, v: BignumRef<'de>) -> Result<Self::Value> {
+        Ok(Value::Bignum(v.into()))
     }
 
     fn visit_f64(self, v: f64) -> Result<Self::Value> {
@@ -224,7 +228,8 @@ impl<'de> DeserializerTrait<'de> for &'de Value {
             Value::Nil => visitor.visit_nil(),
             Value::Bool(v) => visitor.visit_bool(*v),
             Value::Float(f) => visitor.visit_f64(*f),
-            Value::Integer(i) => visitor.visit_bignum(i.clone()),
+            Value::Fixnum(i) => visitor.visit_fixnum(*i),
+            Value::Bignum(i) => visitor.visit_bignum(i.as_ref()),
             Value::String(s) => visitor.visit_string(&s.data),
             Value::Symbol(s) => visitor.visit_symbol(s),
             Value::Array(array) => visitor.visit_array(ValueArrayAccess { array, index: 0 }),

--- a/alox-48/src/value/de.rs
+++ b/alox-48/src/value/de.rs
@@ -27,7 +27,7 @@ impl<'de> Visitor<'de> for ValueVisitor {
         Ok(Value::Bool(v))
     }
 
-    fn visit_i32(self, v: i32) -> Result<Self::Value> {
+    fn visit_bignum(self, v: num_bigint::BigInt) -> Result<Self::Value> {
         Ok(Value::Integer(v))
     }
 
@@ -224,7 +224,7 @@ impl<'de> DeserializerTrait<'de> for &'de Value {
             Value::Nil => visitor.visit_nil(),
             Value::Bool(v) => visitor.visit_bool(*v),
             Value::Float(f) => visitor.visit_f64(*f),
-            Value::Integer(i) => visitor.visit_i32(*i),
+            Value::Integer(i) => visitor.visit_bignum(i.clone()),
             Value::String(s) => visitor.visit_string(&s.data),
             Value::Symbol(s) => visitor.visit_symbol(s),
             Value::Array(array) => visitor.visit_array(ValueArrayAccess { array, index: 0 }),

--- a/alox-48/src/value/from.rs
+++ b/alox-48/src/value/from.rs
@@ -69,8 +69,8 @@ impl From<f64> for Value {
     }
 }
 
-impl From<i32> for Value {
-    fn from(value: i32) -> Self {
+impl From<num_bigint::BigInt> for Value {
+    fn from(value: num_bigint::BigInt) -> Self {
         Self::Integer(value)
     }
 }
@@ -107,10 +107,10 @@ impl TryInto<RbString> for Value {
     }
 }
 
-impl TryInto<i32> for Value {
+impl TryInto<num_bigint::BigInt> for Value {
     type Error = Self;
 
-    fn try_into(self) -> Result<i32, Self::Error> {
+    fn try_into(self) -> Result<num_bigint::BigInt, Self::Error> {
         self.into_integer()
     }
 }

--- a/alox-48/src/value/from.rs
+++ b/alox-48/src/value/from.rs
@@ -63,17 +63,46 @@ impl From<bool> for Value {
     }
 }
 
+impl From<f32> for Value {
+    fn from(value: f32) -> Self {
+        Self::Float(value as _)
+    }
+}
+
 impl From<f64> for Value {
     fn from(value: f64) -> Self {
         Self::Float(value)
     }
 }
 
-impl From<num_bigint::BigInt> for Value {
-    fn from(value: num_bigint::BigInt) -> Self {
-        Self::Integer(value)
-    }
+macro_rules! from_primitive_int_impl {
+    ($($primitive:ty => $from_primitive:ident),* $(,)?) => {
+        $(impl From<$primitive> for Value {
+            fn from(value: $primitive) -> Self {
+                if let Some(fixnum) = num_traits::FromPrimitive::$from_primitive(value) {
+                    Self::Fixnum(fixnum)
+                } else {
+                    Self::Bignum(num_traits::FromPrimitive::$from_primitive(value).unwrap())
+                }
+            }
+        })*
+    };
 }
+
+from_primitive_int_impl!(
+    u8 => from_u8,
+    u16 => from_u16,
+    u32 => from_u32,
+    u64 => from_u64,
+    u128 => from_u128,
+    usize => from_usize,
+    i8 => from_i8,
+    i16 => from_i16,
+    i32 => from_i32,
+    i64 => from_i64,
+    i128 => from_i128,
+    isize => from_isize,
+);
 
 impl From<RbHash> for Value {
     fn from(value: RbHash) -> Self {
@@ -107,13 +136,38 @@ impl TryInto<RbString> for Value {
     }
 }
 
-impl TryInto<num_bigint::BigInt> for Value {
-    type Error = Self;
+macro_rules! to_primitive_int_impl {
+    ($($primitive:ty => $to_primitive:ident),* $(,)?) => {
+        $(impl TryInto<$primitive> for Value {
+            type Error = Self;
 
-    fn try_into(self) -> Result<num_bigint::BigInt, Self::Error> {
-        self.into_integer()
-    }
+            fn try_into(self) -> Result<$primitive, Self::Error> {
+                match self.into_fixnum() {
+                    Ok(fixnum) => num_traits::ToPrimitive::$to_primitive(&fixnum).ok_or(Value::Fixnum(fixnum)),
+                    Err(value) => {
+                        let bignum = value.into_bignum()?;
+                        num_traits::ToPrimitive::$to_primitive(&bignum).ok_or(Value::Bignum(bignum))
+                    }
+                }
+            }
+        })*
+    };
 }
+
+to_primitive_int_impl!(
+    u8 => to_u8,
+    u16 => to_u16,
+    u32 => to_u32,
+    u64 => to_u64,
+    u128 => to_u128,
+    usize => to_usize,
+    i8 => to_i8,
+    i16 => to_i16,
+    i32 => to_i32,
+    i64 => to_i64,
+    i128 => to_i128,
+    isize => to_isize,
+);
 
 impl TryInto<f64> for Value {
     type Error = Self;

--- a/alox-48/src/value/from.rs
+++ b/alox-48/src/value/from.rs
@@ -4,7 +4,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use crate::{FromPrimitive, Instance, ToPrimitive};
+use crate::{Instance, NumCast};
 
 use super::{Object, RbHash, RbString, Symbol, Userdata, Value};
 
@@ -76,33 +76,20 @@ impl From<f64> for Value {
 }
 
 macro_rules! from_primitive_int_impl {
-    ($($primitive:ty => $from_primitive:ident),* $(,)?) => {
+    ($($primitive:ty),* $(,)?) => {
         $(impl From<$primitive> for Value {
             fn from(value: $primitive) -> Self {
-                if let Some(fixnum) = FromPrimitive::$from_primitive(value) {
+                if let Some(fixnum) = NumCast::from(value) {
                     Self::Fixnum(fixnum)
                 } else {
-                    Self::Bignum(FromPrimitive::$from_primitive(value).unwrap())
+                    Self::Bignum(NumCast::from(value).unwrap())
                 }
             }
         })*
     };
 }
 
-from_primitive_int_impl!(
-    u8 => from_u8,
-    u16 => from_u16,
-    u32 => from_u32,
-    u64 => from_u64,
-    u128 => from_u128,
-    usize => from_usize,
-    i8 => from_i8,
-    i16 => from_i16,
-    i32 => from_i32,
-    i64 => from_i64,
-    i128 => from_i128,
-    isize => from_isize,
-);
+from_primitive_int_impl!(u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize);
 
 impl From<RbHash> for Value {
     fn from(value: RbHash) -> Self {
@@ -137,16 +124,16 @@ impl TryInto<RbString> for Value {
 }
 
 macro_rules! to_primitive_int_impl {
-    ($($primitive:ty => $to_primitive:ident),* $(,)?) => {
+    ($($primitive:ty),* $(,)?) => {
         $(impl TryInto<$primitive> for Value {
             type Error = Self;
 
             fn try_into(self) -> Result<$primitive, Self::Error> {
                 match self.into_fixnum() {
-                    Ok(fixnum) => fixnum.$to_primitive().ok_or(Value::Fixnum(fixnum)),
+                    Ok(fixnum) => <$primitive as NumCast>::from(fixnum).ok_or(Value::Fixnum(fixnum)),
                     Err(value) => {
                         let bignum = value.into_bignum()?;
-                        bignum.$to_primitive().ok_or(Value::Bignum(bignum))
+                        <$primitive as NumCast>::from(bignum.as_ref()).ok_or(Value::Bignum(bignum))
                     }
                 }
             }
@@ -154,20 +141,7 @@ macro_rules! to_primitive_int_impl {
     };
 }
 
-to_primitive_int_impl!(
-    u8 => to_u8,
-    u16 => to_u16,
-    u32 => to_u32,
-    u64 => to_u64,
-    u128 => to_u128,
-    usize => to_usize,
-    i8 => to_i8,
-    i16 => to_i16,
-    i32 => to_i32,
-    i64 => to_i64,
-    i128 => to_i128,
-    isize => to_isize,
-);
+to_primitive_int_impl!(u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize);
 
 impl TryInto<f64> for Value {
     type Error = Self;

--- a/alox-48/src/value/from.rs
+++ b/alox-48/src/value/from.rs
@@ -4,7 +4,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use crate::Instance;
+use crate::{FromPrimitive, Instance, ToPrimitive};
 
 use super::{Object, RbHash, RbString, Symbol, Userdata, Value};
 
@@ -79,10 +79,10 @@ macro_rules! from_primitive_int_impl {
     ($($primitive:ty => $from_primitive:ident),* $(,)?) => {
         $(impl From<$primitive> for Value {
             fn from(value: $primitive) -> Self {
-                if let Some(fixnum) = num_traits::FromPrimitive::$from_primitive(value) {
+                if let Some(fixnum) = FromPrimitive::$from_primitive(value) {
                     Self::Fixnum(fixnum)
                 } else {
-                    Self::Bignum(num_traits::FromPrimitive::$from_primitive(value).unwrap())
+                    Self::Bignum(FromPrimitive::$from_primitive(value).unwrap())
                 }
             }
         })*
@@ -143,10 +143,10 @@ macro_rules! to_primitive_int_impl {
 
             fn try_into(self) -> Result<$primitive, Self::Error> {
                 match self.into_fixnum() {
-                    Ok(fixnum) => num_traits::ToPrimitive::$to_primitive(&fixnum).ok_or(Value::Fixnum(fixnum)),
+                    Ok(fixnum) => fixnum.$to_primitive().ok_or(Value::Fixnum(fixnum)),
                     Err(value) => {
                         let bignum = value.into_bignum()?;
-                        num_traits::ToPrimitive::$to_primitive(&bignum).ok_or(Value::Bignum(bignum))
+                        bignum.$to_primitive().ok_or(Value::Bignum(bignum))
                     }
                 }
             }

--- a/alox-48/src/value/impls.rs
+++ b/alox-48/src/value/impls.rs
@@ -4,6 +4,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 use super::{Bignum, Fixnum, Object, RbArray, RbHash, RbString, Symbol, Userdata, Value};
+use crate::FromPrimitive;
 
 impl PartialEq for Value {
     #[allow(clippy::too_many_lines)]
@@ -181,8 +182,8 @@ macro_rules! primitive_int_impl {
         $(impl PartialEq<$primitive> for Value {
             fn eq(&self, other: &$primitive) -> bool {
                 match self {
-                    Value::Fixnum(v) => <Fixnum as num_traits::FromPrimitive>::$from_primitive(*other).is_some_and(|other| other == *v),
-                    Value::Bignum(v) => <Bignum as num_traits::FromPrimitive>::$from_primitive(*other).is_some_and(|other| other == *v),
+                    Value::Fixnum(v) => Fixnum::$from_primitive(*other).is_some_and(|other| other == *v),
+                    Value::Bignum(v) => Bignum::$from_primitive(*other).is_some_and(|other| other == *v),
                     _ => false,
                 }
             }

--- a/alox-48/src/value/impls.rs
+++ b/alox-48/src/value/impls.rs
@@ -169,8 +169,8 @@ impl PartialEq<bool> for Value {
     }
 }
 
-impl PartialEq<i32> for Value {
-    fn eq(&self, other: &i32) -> bool {
+impl PartialEq<num_bigint::BigInt> for Value {
+    fn eq(&self, other: &num_bigint::BigInt) -> bool {
         match self {
             Value::Integer(v) => other == v,
             _ => false,

--- a/alox-48/src/value/impls.rs
+++ b/alox-48/src/value/impls.rs
@@ -3,7 +3,7 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
-use super::{Object, RbArray, RbHash, RbString, Symbol, Userdata, Value};
+use super::{Bignum, Fixnum, Object, RbArray, RbHash, RbString, Symbol, Userdata, Value};
 
 impl PartialEq for Value {
     #[allow(clippy::too_many_lines)]
@@ -24,8 +24,15 @@ impl PartialEq for Value {
                     false
                 }
             }
-            Value::Integer(i) => {
-                if let Value::Integer(i2) = other {
+            Value::Fixnum(i) => {
+                if let Value::Fixnum(i2) = other {
+                    i == i2
+                } else {
+                    false
+                }
+            }
+            Value::Bignum(i) => {
+                if let Value::Bignum(i2) = other {
                     i == i2
                 } else {
                     false
@@ -169,14 +176,34 @@ impl PartialEq<bool> for Value {
     }
 }
 
-impl PartialEq<num_bigint::BigInt> for Value {
-    fn eq(&self, other: &num_bigint::BigInt) -> bool {
-        match self {
-            Value::Integer(v) => other == v,
-            _ => false,
-        }
-    }
+macro_rules! primitive_int_impl {
+    ($($primitive:ty => $from_primitive:ident),* $(,)?) => {
+        $(impl PartialEq<$primitive> for Value {
+            fn eq(&self, other: &$primitive) -> bool {
+                match self {
+                    Value::Fixnum(v) => <Fixnum as num_traits::FromPrimitive>::$from_primitive(*other).is_some_and(|other| other == *v),
+                    Value::Bignum(v) => <Bignum as num_traits::FromPrimitive>::$from_primitive(*other).is_some_and(|other| other == *v),
+                    _ => false,
+                }
+            }
+        })*
+    };
 }
+
+primitive_int_impl!(
+    u8 => from_u8,
+    u16 => from_u16,
+    u32 => from_u32,
+    u64 => from_u64,
+    u128 => from_u128,
+    usize => from_usize,
+    i8 => from_i8,
+    i16 => from_i16,
+    i32 => from_i32,
+    i64 => from_i64,
+    i128 => from_i128,
+    isize => from_isize,
+);
 
 impl PartialEq<f64> for Value {
     fn eq(&self, other: &f64) -> bool {
@@ -273,7 +300,8 @@ impl std::hash::Hash for Value {
             Value::Nil => {}
             Value::Bool(b) => b.hash(state),
             Value::Float(f) => f.to_bits().hash(state), // not the best but eh whos using a float as a hash key
-            Value::Integer(i) => i.hash(state),
+            Value::Fixnum(i) => i32::from(*i).hash(state),
+            Value::Bignum(i) => i.as_le_bytes().hash(state),
             Value::String(s) => {
                 s.data.hash(state);
             }

--- a/alox-48/src/value/impls.rs
+++ b/alox-48/src/value/impls.rs
@@ -4,7 +4,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 use super::{Bignum, Fixnum, Object, RbArray, RbHash, RbString, Symbol, Userdata, Value};
-use crate::FromPrimitive;
+use crate::NumCast;
 
 impl PartialEq for Value {
     #[allow(clippy::too_many_lines)]
@@ -178,12 +178,12 @@ impl PartialEq<bool> for Value {
 }
 
 macro_rules! primitive_int_impl {
-    ($($primitive:ty => $from_primitive:ident),* $(,)?) => {
+    ($($primitive:ty),* $(,)?) => {
         $(impl PartialEq<$primitive> for Value {
             fn eq(&self, other: &$primitive) -> bool {
                 match self {
-                    Value::Fixnum(v) => Fixnum::$from_primitive(*other).is_some_and(|other| other == *v),
-                    Value::Bignum(v) => Bignum::$from_primitive(*other).is_some_and(|other| other == *v),
+                    Value::Fixnum(v) => <Fixnum as NumCast>::from(*other).is_some_and(|other| other == *v),
+                    Value::Bignum(v) => <Bignum as NumCast>::from(*other).is_some_and(|other| other == *v),
                     _ => false,
                 }
             }
@@ -191,20 +191,7 @@ macro_rules! primitive_int_impl {
     };
 }
 
-primitive_int_impl!(
-    u8 => from_u8,
-    u16 => from_u16,
-    u32 => from_u32,
-    u64 => from_u64,
-    u128 => from_u128,
-    usize => from_usize,
-    i8 => from_i8,
-    i16 => from_i16,
-    i32 => from_i32,
-    i64 => from_i64,
-    i128 => from_i128,
-    isize => from_isize,
-);
+primitive_int_impl!(u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize);
 
 impl PartialEq<f64> for Value {
     fn eq(&self, other: &f64) -> bool {
@@ -301,7 +288,7 @@ impl std::hash::Hash for Value {
             Value::Nil => {}
             Value::Bool(b) => b.hash(state),
             Value::Float(f) => f.to_bits().hash(state), // not the best but eh whos using a float as a hash key
-            Value::Fixnum(i) => i32::from(*i).hash(state),
+            Value::Fixnum(i) => <i32 as From<_>>::from(*i).hash(state),
             Value::Bignum(i) => i.as_le_bytes().hash(state),
             Value::String(s) => {
                 s.data.hash(state);

--- a/alox-48/src/value/mod.rs
+++ b/alox-48/src/value/mod.rs
@@ -29,7 +29,7 @@ pub enum Value {
     /// A float value.
     Float(f64),
     /// An integer value.
-    Integer(i32),
+    Integer(num_bigint::BigInt),
     /// A ruby string.
     /// Because strings in ruby are not guarenteed to be utf8, [`RbString`] stores a [`Vec<u8>`] instead.
     ///

--- a/alox-48/src/value/mod.rs
+++ b/alox-48/src/value/mod.rs
@@ -13,7 +13,7 @@ pub use ser::Serializer;
 
 use crate::{
     rb_types::{Object, RbArray, RbFields, RbHash, RbString, Symbol, Userdata},
-    Instance, RbStruct,
+    Bignum, Fixnum, Instance, RbStruct,
 };
 
 /// An enum representing any ruby value.
@@ -28,8 +28,10 @@ pub enum Value {
     Bool(bool),
     /// A float value.
     Float(f64),
-    /// An integer value.
-    Integer(num_bigint::BigInt),
+    /// An integer value within the interval $[-2^30, 2^30)$.
+    Fixnum(Fixnum),
+    /// An integer value outside of the interval $[-2^30, 2^30)$.
+    Bignum(Bignum),
     /// A ruby string.
     /// Because strings in ruby are not guarenteed to be utf8, [`RbString`] stores a [`Vec<u8>`] instead.
     ///

--- a/alox-48/src/value/mod.rs
+++ b/alox-48/src/value/mod.rs
@@ -28,9 +28,9 @@ pub enum Value {
     Bool(bool),
     /// A float value.
     Float(f64),
-    /// An integer value within the interval $[-2^30, 2^30)$.
+    /// An integer value within the interval [-2<sup>30</sup>, 2<sup>30</sup>).
     Fixnum(Fixnum),
-    /// An integer value outside of the interval $[-2^30, 2^30)$.
+    /// An integer value outside of the interval [-2<sup>30</sup>, 2<sup>30</sup>).
     Bignum(Bignum),
     /// A ruby string.
     /// Because strings in ruby are not guarenteed to be utf8, [`RbString`] stores a [`Vec<u8>`] instead.

--- a/alox-48/src/value/ser.rs
+++ b/alox-48/src/value/ser.rs
@@ -6,7 +6,7 @@
 use super::{Object, RbFields, RbHash, RbString, Symbol, Userdata, Value};
 use crate::{
     ser::{Error, Kind, Result, Serialize},
-    Instance, RbArray, RbStruct, SerializerTrait, Sym,
+    BignumRef, Fixnum, Instance, RbArray, RbStruct, SerializerTrait, Sym,
 };
 
 impl Serialize for Value {
@@ -18,7 +18,8 @@ impl Serialize for Value {
             Value::Nil => serializer.serialize_nil(),
             Value::Bool(v) => serializer.serialize_bool(*v),
             Value::Float(f) => serializer.serialize_f64(*f),
-            Value::Integer(i) => serializer.serialize_bignum(i.clone()),
+            Value::Fixnum(i) => serializer.serialize_fixnum(*i),
+            Value::Bignum(i) => serializer.serialize_bignum(i.as_ref()),
             Value::String(s) => s.serialize(serializer),
             Value::Symbol(s) => s.serialize(serializer),
             Value::Array(a) => a.serialize(serializer),
@@ -86,8 +87,12 @@ impl SerializerTrait for Serializer {
         Ok(Value::Bool(v))
     }
 
-    fn serialize_bignum(self, v: num_bigint::BigInt) -> Result<Self::Ok> {
-        Ok(Value::Integer(v))
+    fn serialize_fixnum(self, v: Fixnum) -> Result<Self::Ok> {
+        Ok(Value::Fixnum(v))
+    }
+
+    fn serialize_bignum(self, v: BignumRef<'_>) -> Result<Self::Ok> {
+        Ok(Value::Bignum(v.into()))
     }
 
     fn serialize_f64(self, v: f64) -> Result<Self::Ok> {

--- a/alox-48/src/value/ser.rs
+++ b/alox-48/src/value/ser.rs
@@ -18,7 +18,7 @@ impl Serialize for Value {
             Value::Nil => serializer.serialize_nil(),
             Value::Bool(v) => serializer.serialize_bool(*v),
             Value::Float(f) => serializer.serialize_f64(*f),
-            Value::Integer(i) => serializer.serialize_i32(*i),
+            Value::Integer(i) => serializer.serialize_bignum(i.clone()),
             Value::String(s) => s.serialize(serializer),
             Value::Symbol(s) => s.serialize(serializer),
             Value::Array(a) => a.serialize(serializer),
@@ -86,7 +86,7 @@ impl SerializerTrait for Serializer {
         Ok(Value::Bool(v))
     }
 
-    fn serialize_i32(self, v: i32) -> Result<Self::Ok> {
+    fn serialize_bignum(self, v: num_bigint::BigInt) -> Result<Self::Ok> {
         Ok(Value::Integer(v))
     }
 


### PR DESCRIPTION
This is required to correctly serialize and deserialize integer values outside of the range of a 32-bit signed integer.

I'm implementing this because apparently the ID of a script in RPG Maker XP can be larger than a 32-bit signed integer. Someone reported issues loading their scripts in Luminol because of this.